### PR TITLE
Add implementations for plus/minus/per with numeric operands.

### DIFF
--- a/src/unit.ts
+++ b/src/unit.ts
@@ -670,7 +670,9 @@ class QuantityImpl<D extends Dimensions> implements Quantity<D> {
 
   per(amount: number): Quantity<D>;
   per<D2 extends Divisor<D>>(quantity: Quantity<D2>): Quantity<Over<D, D2>>;
-  per<D2 extends Divisor<D>>(other: number | Quantity<D2>): Quantity<D> | Quantity<Over<D, D2>> {
+  per<D2 extends Divisor<D>>(
+    other: number | Quantity<D2>
+  ): Quantity<D> | Quantity<Over<D, D2>> {
     if (typeof other === 'number') {
       return new QuantityImpl(this.amount / other, this.unit);
     }

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -244,6 +244,7 @@ export interface Quantity<D extends Dimensions> {
    *
    * @param quantity The quantity to add to this one.
    */
+  plus(quantity: number): Quantity<D>;
   plus(quantity: Quantity<D>): Quantity<D>;
 
   /**
@@ -257,6 +258,7 @@ export interface Quantity<D extends Dimensions> {
    *
    * @param quantity The quantity to subtract from this one.
    */
+  minus(quantity: number): Quantity<D>;
   minus(quantity: Quantity<D>): Quantity<D>;
 
   /**
@@ -297,6 +299,7 @@ export interface Quantity<D extends Dimensions> {
    *
    * @param quantity The quantity to divide this one with.
    */
+  per(quantity: number): Quantity<D>;
   per<D2 extends Divisor<D>>(quantity: Quantity<D2>): Quantity<Over<D, D2>>;
 
   /**
@@ -607,14 +610,26 @@ class QuantityImpl<D extends Dimensions> implements Quantity<D> {
     return new QuantityImpl(this.valueOf() / other.scale + other.offset, other);
   }
 
-  plus(quantity: Quantity<D>) {
+  plus(quantity: number): Quantity<D>;
+  plus(quantity: Quantity<D>): Quantity<D>;
+  plus(quantity: number | Quantity<D>) {
+    if (typeof quantity === 'number') {
+      return new QuantityImpl(this.amount + quantity, this.unit);
+    }
+
     return new QuantityImpl(
       this.in(quantity.unit).amount + quantity.amount,
       quantity.unit
     );
   }
 
-  minus(quantity: Quantity<D>) {
+  minus(quantity: number): Quantity<D>;
+  minus(quantity: Quantity<D>): Quantity<D>;
+  minus(quantity: number | Quantity<D>) {
+    if (typeof quantity === 'number') {
+      return new QuantityImpl(this.amount - quantity, this.unit);
+    }
+
     return new QuantityImpl(
       this.in(quantity.unit).amount - quantity.amount,
       quantity.unit
@@ -653,7 +668,13 @@ class QuantityImpl<D extends Dimensions> implements Quantity<D> {
     );
   }
 
-  per<D2 extends Divisor<D>>(other: Quantity<D2>): Quantity<Over<D, D2>> {
+  per(amount: number): Quantity<D>;
+  per<D2 extends Divisor<D>>(quantity: Quantity<D2>): Quantity<Over<D, D2>>;
+  per<D2 extends Divisor<D>>(other: number | Quantity<D2>): Quantity<D> | Quantity<Over<D, D2>> {
+    if (typeof other === 'number') {
+      return new QuantityImpl(this.amount / other, this.unit);
+    }
+
     if (other.isDimensionless()) {
       return new QuantityImpl(
         this.amount / other.amount / other.unit.scale,

--- a/test/unit_test.ts
+++ b/test/unit_test.ts
@@ -284,23 +284,41 @@ describe('unit', () => {
         expect(length.amount).to.be.closeTo(13.8425, 0.0001);
         expect(length.unit).to.equal(feet);
       });
+    });
 
-      describe('minus', () => {
-        it('subtracts the amount', () => {
-          const meters = makeUnit('m', Length);
-          const length = meters(3).minus(meters(4));
-          expect(length.amount).to.equal(-1);
-          expect(length.unit).to.equal(meters);
-        });
+    describe('plus number', () => {
+      it('adds the amounts', () => {
+        const meters = makeUnit('m', Length);
+        const length = meters(5).plus(10);
+        expect(length.amount).to.equal(15);
+        expect(length.unit).to.equal(meters);
+      });
+    });
 
-        it('converts to the given unit', () => {
-          const meters = makeUnit('m', Length);
-          const feet = meters.times(0.3048);
+    describe('minus', () => {
+      it('subtracts the amount', () => {
+        const meters = makeUnit('m', Length);
+        const length = meters(3).minus(meters(4));
+        expect(length.amount).to.equal(-1);
+        expect(length.unit).to.equal(meters);
+      });
 
-          const length = meters(3).minus(feet(4));
-          expect(length.amount).to.be.closeTo(5.8425, 0.0001);
-          expect(length.unit).to.equal(feet);
-        });
+      it('converts to the given unit', () => {
+        const meters = makeUnit('m', Length);
+        const feet = meters.times(0.3048);
+
+        const length = meters(3).minus(feet(4));
+        expect(length.amount).to.be.closeTo(5.8425, 0.0001);
+        expect(length.unit).to.equal(feet);
+      });
+    });
+
+    describe('minus number', () => {
+      it('subtracts the amounts', () => {
+        const meters = makeUnit('m', Length);
+        const length = meters(15).minus(5);
+        expect(length.amount).to.equal(10);
+        expect(length.unit).to.equal(meters);
       });
     });
 
@@ -393,6 +411,15 @@ describe('unit', () => {
         const length = feet(50).per(percent(10));
         expect(length.amount).to.be.closeTo(500, 1e-10);
         expect(length.unit).to.equal(feet);
+      });
+    });
+
+    describe('per number', () => {
+      it('divides the amount', () => {
+        const meters = makeUnit('m', Length);
+        const length = meters(10).per(2);
+        expect(length.amount).to.equal(5);
+        expect(length.unit).to.equal(meters);
       });
     });
 


### PR DESCRIPTION
This already existed for `times()`, but not for the others.

For tests, the `describe()` block for `minus()` was inside the `describe()` block for `plus()`, so I just moved it out since it looked like a typo.