### PR TITLE
Implement alternative to native representation of numbers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,19 @@
   ],
   "rules": {
     "prettier/prettier": ["error"],
-    "sort-imports": ["error"]
+    "sort-imports": ["error"],
+    "@typescript-eslint/explicit-module-boundary-types": [
+      "warn",
+      {
+        "allowedNames": ["makeUnitFactory"]
+      }
+    ],
+    "@typescript-eslint/no-empty-function": [
+      "error",
+      {
+        "allow": ["private-constructors"]
+      }
+    ]
   },
   "overrides": [
     {

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "@typescript-eslint/explicit-module-boundary-types": [
       "warn",
       {
-        "allowedNames": ["makeUnitFactory"]
+        "allowedNames": ["makeUnitFactory", "withValueType"]
       }
     ],
     "@typescript-eslint/no-empty-function": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/launch.json
+.idea
 build
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
       "version": "1.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/chai": "^4.2.12",
-        "@types/mocha": "^9.0.0",
-        "@typescript-eslint/eslint-plugin": "^4.1.0",
-        "@typescript-eslint/parser": "^4.1.0",
-        "chai": "^4.2.0",
-        "eslint": "^7.9.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "kelonio": "^0.7.0",
-        "mocha": "^9.1.0",
-        "mocha-multi": "^1.1.5",
-        "prettier": "^2.1.1",
+        "@types/chai": "^4.3.4",
+        "@types/mocha": "^10.0.1",
+        "@typescript-eslint/eslint-plugin": "^5.57.0",
+        "@typescript-eslint/parser": "^5.57.0",
+        "chai": "^4.3.7",
+        "eslint": "^8.37.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "kelonio": "^0.9.0",
+        "mocha": "^10.2.0",
+        "mocha-multi": "^1.1.7",
+        "prettier": "^2.8.7",
         "release-it": "*",
-        "ts-node": "^10.2.1",
-        "typescript": "^4.1.6"
+        "ts-node": "^10.9.1",
+        "typescript": "^5.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -130,12 +130,12 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dev": true,
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -153,47 +153,87 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "debug": "^4.3.2",
+        "espree": "^9.5.1",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+    "node_modules/@eslint/js": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
       "dev": true,
       "engines": {
-        "node": ">= 4"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.0",
+        "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
@@ -545,9 +585,9 @@
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
@@ -563,9 +603,9 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -581,31 +621,39 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
+      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/type-utils": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -613,50 +661,26 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -665,29 +689,56 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
+      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
       "dev": true,
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -695,21 +746,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -721,33 +772,53 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -831,15 +902,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -911,13 +973,10 @@
       "dev": true
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -966,15 +1025,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/async-retry": {
@@ -1219,14 +1269,14 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -1597,9 +1647,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
-      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
     "node_modules/decompress-response": {
@@ -1630,15 +1680,15 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -1800,18 +1850,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2015,66 +2053,66 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.37.0",
+        "@humanwhocodes/config-array": "^0.11.8",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -2084,19 +2122,19 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=5.0.0",
-        "prettier": ">=1.13.0"
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "eslint-config-prettier": {
@@ -2117,87 +2155,67 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
       "engines": {
-        "node": ">=4"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
-        "node": ">= 4"
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -2214,9 +2232,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -2642,12 +2660,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -2810,9 +2822,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2875,14 +2887,11 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -3697,6 +3706,16 @@
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
       "dev": true
     },
+    "node_modules/js-sdsl": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3704,13 +3723,12 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -3750,13 +3768,13 @@
       }
     },
     "node_modules/kelonio": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kelonio/-/kelonio-0.7.0.tgz",
-      "integrity": "sha512-XSU6NORWsQlpSq32SaVsYyDGIVHrsM+fWFypZJFphuQh3qLozd8nBDc9d42JAyfVbeUnEuovJ0W99AuGUvY9Ig==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/kelonio/-/kelonio-0.9.0.tgz",
+      "integrity": "sha512-ucf1wWvR5mG24E8NhG7L6WI8ZozhA4B9ikAlcRgftCJYKYEmNl5q2JQFPAryHJbHts8TIIVD5XShGSm5x7BWfQ==",
       "dev": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0",
-        "mathjs": "^9.4.2"
+        "mathjs": "^10.5.2"
       }
     },
     "node_modules/keyv": {
@@ -3835,12 +3853,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -3906,26 +3918,26 @@
       "dev": true
     },
     "node_modules/mathjs": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.5.2.tgz",
-      "integrity": "sha512-c0erTq0GP503/Ch2OtDOAn50GIOsuxTMjmE00NI/vKJFSWrDaQHRjx6ai+16xYv70yBSnnpUgHZGNf9FR9IwmA==",
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
+      "integrity": "sha512-omQyvRE1jIy+3k2qsqkWASOcd45aZguXZDckr3HtnTYyXk5+2xpVfC3kATgbO2Srjxlqww3TVdhD0oUdZ/hiFA==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "complex.js": "^2.0.15",
+        "@babel/runtime": "^7.18.6",
+        "complex.js": "^2.1.1",
         "decimal.js": "^10.3.1",
         "escape-latex": "^1.2.0",
-        "fraction.js": "^4.1.1",
+        "fraction.js": "^4.2.0",
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^2.0.0"
+        "typed-function": "^2.1.0"
       },
       "bin": {
         "mathjs": "bin/cli.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14"
       }
     },
     "node_modules/merge-stream": {
@@ -4035,42 +4047,39 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4078,9 +4087,9 @@
       }
     },
     "node_modules/mocha-multi": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mocha-multi/-/mocha-multi-1.1.6.tgz",
-      "integrity": "sha512-hMVmd9C1h4PEiFNwHxn8aa5/EgGLg0UswdOrlrq1Y8ieKmot8hZLYaiESIgg/He3E4oxwaXPWT1V1PJ0qNJlUQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi/-/mocha-multi-1.1.7.tgz",
+      "integrity": "sha512-SXZRgHy0XiRTASyOp0p6fjOkdj+R62L6cqutnYyQOvIjNznJuUwzykxctypeRiOwPd+gfn4yt3NRulMQyI8Tzg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -4093,7 +4102,7 @@
         "node": ">=6.0.0"
       },
       "peerDependencies": {
-        "mocha": ">=2.2.0 <7 || ^9"
+        "mocha": ">=2.2.0 <7 || >=9"
       }
     },
     "node_modules/mocha/node_modules/ansi-colors": {
@@ -4105,54 +4114,22 @@
         "node": ">=6"
       }
     },
-    "node_modules/mocha/node_modules/argparse": {
+    "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -4192,9 +4169,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -4207,6 +4184,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/netmask": {
@@ -4760,9 +4743,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -4784,15 +4767,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/promise.allsettled": {
@@ -4853,9 +4827,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5001,9 +4975,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
@@ -5021,18 +4995,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/registry-auth-token": {
@@ -5192,15 +5154,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5544,23 +5497,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -5614,12 +5550,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -5771,64 +5701,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/table/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5929,18 +5801,6 @@
         }
       }
     },
-    "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -6029,16 +5889,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6159,12 +6019,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6185,18 +6039,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/wcwidth": {
@@ -6399,9 +6241,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -6705,12 +6547,12 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@cspotcode/source-map-support": {
@@ -6722,41 +6564,60 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "debug": "^4.3.2",
+        "espree": "^9.5.1",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
-        }
       }
     },
+    "@eslint/js": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
+      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "requires": {
-        "@humanwhocodes/object-schema": "^1.2.0",
+        "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -7035,9 +6896,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
     "@types/http-cache-semantics": {
@@ -7053,9 +6914,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
     "@types/node": {
@@ -7071,99 +6932,115 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      }
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
+      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/type-utils": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
       }
     },
-    "@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+    "@typescript-eslint/type-utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
+      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
-    "@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
-      }
-    },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+    "@typescript-eslint/types": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
       "dev": true
     },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.57.0",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -7228,12 +7105,6 @@
         }
       }
     },
-    "ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -7283,13 +7154,10 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-union": {
       "version": "2.1.0",
@@ -7324,12 +7192,6 @@
       "requires": {
         "tslib": "^2.0.1"
       }
-    },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
     },
     "async-retry": {
       "version": "1.3.3",
@@ -7502,14 +7364,14 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -7776,9 +7638,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
-      "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
     "decompress-response": {
@@ -7799,9 +7661,9 @@
       }
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -7924,15 +7786,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
-    },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -8087,89 +7940,91 @@
       }
     },
     "eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.37.0",
+        "@humanwhocodes/config-array": "^0.11.8",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-              "dev": true
-            }
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
           }
         },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "requires": {}
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -8185,38 +8040,21 @@
         "estraverse": "^4.1.1"
       }
     },
-    "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^2.0.0"
-      }
-    },
     "eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true
     },
     "espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dev": true,
       "requires": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.0"
       }
     },
     "esprima": {
@@ -8226,9 +8064,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -8545,12 +8383,6 @@
         "functions-have-names": "^1.2.2"
       }
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -8670,9 +8502,9 @@
       }
     },
     "globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -8717,10 +8549,10 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "has": {
@@ -9275,6 +9107,12 @@
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
       "dev": true
     },
+    "js-sdsl": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9282,13 +9120,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "json-buffer": {
@@ -9325,13 +9162,13 @@
       }
     },
     "kelonio": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kelonio/-/kelonio-0.7.0.tgz",
-      "integrity": "sha512-XSU6NORWsQlpSq32SaVsYyDGIVHrsM+fWFypZJFphuQh3qLozd8nBDc9d42JAyfVbeUnEuovJ0W99AuGUvY9Ig==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/kelonio/-/kelonio-0.9.0.tgz",
+      "integrity": "sha512-ucf1wWvR5mG24E8NhG7L6WI8ZozhA4B9ikAlcRgftCJYKYEmNl5q2JQFPAryHJbHts8TIIVD5XShGSm5x7BWfQ==",
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0",
-        "mathjs": "^9.4.2"
+        "mathjs": "^10.5.2"
       }
     },
     "keyv": {
@@ -9395,12 +9232,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
-    "lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
-    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -9448,20 +9279,20 @@
       "dev": true
     },
     "mathjs": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.5.2.tgz",
-      "integrity": "sha512-c0erTq0GP503/Ch2OtDOAn50GIOsuxTMjmE00NI/vKJFSWrDaQHRjx6ai+16xYv70yBSnnpUgHZGNf9FR9IwmA==",
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
+      "integrity": "sha512-omQyvRE1jIy+3k2qsqkWASOcd45aZguXZDckr3HtnTYyXk5+2xpVfC3kATgbO2Srjxlqww3TVdhD0oUdZ/hiFA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.15.4",
-        "complex.js": "^2.0.15",
+        "@babel/runtime": "^7.18.6",
+        "complex.js": "^2.1.1",
         "decimal.js": "^10.3.1",
         "escape-latex": "^1.2.0",
-        "fraction.js": "^4.1.1",
+        "fraction.js": "^4.2.0",
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^2.0.0"
+        "typed-function": "^2.1.0"
       }
     },
     "merge-stream": {
@@ -9535,32 +9366,29 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -9572,45 +9400,22 @@
           "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
           "dev": true
         },
-        "argparse": {
+        "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
+            "balanced-match": "^1.0.0"
           }
         },
         "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
           }
         },
         "ms": {
@@ -9631,9 +9436,9 @@
       }
     },
     "mocha-multi": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mocha-multi/-/mocha-multi-1.1.6.tgz",
-      "integrity": "sha512-hMVmd9C1h4PEiFNwHxn8aa5/EgGLg0UswdOrlrq1Y8ieKmot8hZLYaiESIgg/He3E4oxwaXPWT1V1PJ0qNJlUQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi/-/mocha-multi-1.1.7.tgz",
+      "integrity": "sha512-SXZRgHy0XiRTASyOp0p6fjOkdj+R62L6cqutnYyQOvIjNznJuUwzykxctypeRiOwPd+gfn4yt3NRulMQyI8Tzg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -9656,15 +9461,21 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "netmask": {
@@ -10033,9 +9844,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -10046,12 +9857,6 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
     },
     "promise.allsettled": {
       "version": "1.0.5",
@@ -10102,9 +9907,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "pupa": {
@@ -10205,9 +10010,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -10220,12 +10025,6 @@
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
       }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
     },
     "registry-auth-token": {
       "version": "5.0.1",
@@ -10341,12 +10140,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve": {
@@ -10581,17 +10374,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
     "smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -10633,12 +10415,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
     },
     "statuses": {
       "version": "2.0.1",
@@ -10741,56 +10517,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
-    "table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-      "dev": true,
-      "requires": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10860,12 +10586,6 @@
         "yn": "3.1.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-          "dev": true
-        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -10934,9 +10654,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -11029,12 +10749,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
-    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -11049,14 +10763,6 @@
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-          "dev": true
-        }
       }
     },
     "wcwidth": {
@@ -11204,9 +10910,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -68,20 +68,20 @@
     "release": "release-it"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.12",
-    "@types/mocha": "^9.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.1.0",
-    "@typescript-eslint/parser": "^4.1.0",
-    "chai": "^4.2.0",
-    "eslint": "^7.9.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^3.1.4",
-    "kelonio": "^0.7.0",
-    "mocha": "^9.1.0",
-    "mocha-multi": "^1.1.5",
-    "prettier": "^2.1.1",
+    "@types/chai": "^4.3.4",
+    "@types/mocha": "^10.0.1",
+    "@typescript-eslint/eslint-plugin": "^5.57.0",
+    "@typescript-eslint/parser": "^5.57.0",
+    "chai": "^4.3.7",
+    "eslint": "^8.37.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "kelonio": "^0.9.0",
+    "mocha": "^10.2.0",
+    "mocha-multi": "^1.1.7",
+    "prettier": "^2.8.7",
     "release-it": "*",
-    "ts-node": "^10.2.1",
-    "typescript": "^4.1.6"
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.3"
   }
 }

--- a/src/angle/index.ts
+++ b/src/angle/index.ts
@@ -1,7 +1,7 @@
 import * as dimension from './dimension';
 import {Quantity, makeUnit} from '../unit';
 
-export type Angle = Quantity<dimension.Angle>;
+export type Angle<NumberType = number> = Quantity<NumberType, dimension.Angle>;
 
 export const radians = makeUnit('rad', dimension.Angle);
 export const degrees = radians.times(Math.PI / 180).withSymbol('º');

--- a/src/angle/index.ts
+++ b/src/angle/index.ts
@@ -70,7 +70,6 @@ export function withValueType<NumberType>(
      * @param y A numeric expression representing the cartesian y-coordinate.
      */
     static atan2(x: NumberType, y: NumberType): Angle<NumberType> {
-      // TODO: Ideally, we should not use toNative here
       return WithValueType.radians(toNative(atan2(x, y)));
     }
   }
@@ -78,7 +77,6 @@ export function withValueType<NumberType>(
   function liftRet(
     f: (x: NumberType) => NumberType
   ): (x: NumberType) => Angle<NumberType> {
-    // TODO: Ideally, we should not use toNative here
     return x => WithValueType.radians(toNative(f(x)));
   }
 

--- a/src/angle/index.ts
+++ b/src/angle/index.ts
@@ -1,63 +1,90 @@
 import * as dimension from './dimension';
-import {Quantity, makeUnit} from '../unit';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Quantity, makeUnitFactory} from '../unit';
 
 export type Angle<NumberType = number> = Quantity<NumberType, dimension.Angle>;
 
-export const radians = makeUnit('rad', dimension.Angle);
-export const degrees = radians.times(Math.PI / 180).withSymbol('º');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
+  const {toNative, sin, cos, tan, asin, acos, atan, atan2} = arithmetic;
 
-export const turns = radians.times(2 * Math.PI).withSymbol('τ');
+  class WithValueType {
+    private constructor() {}
 
-/**
- * Returns the sine of an angle.
- * @param x An Angle
- */
-export const sin = liftUnary(Math.sin);
+    static radians = makeUnit('rad', dimension.Angle);
+    static degrees = WithValueType.radians
+      .times(Math.PI)
+      .per(180)
+      .withSymbol('º');
 
-/**
- * Returns the cosine of an angle.
- * @param x An Angle
- */
-export const cos = liftUnary(Math.cos);
+    static turns = WithValueType.radians
+      .times(2)
+      .times(Math.PI)
+      .withSymbol('τ');
 
-/**
- * Returns the tangent of an angle.
- * @param x An Angle
- */
-export const tan = liftUnary(Math.tan);
+    /**
+     * Returns the sine of an angle.
+     * @param x An Angle
+     */
+    static sin = liftUnary(sin);
 
-/**
- * Returns the arcsine of a number.
- * @param x A numeric expression.
- */
-export const asin = liftRet(Math.asin);
+    /**
+     * Returns the cosine of an angle.
+     * @param x An Angle
+     */
+    static cos = liftUnary(cos);
 
-/**
- * Returns the arc cosine (or inverse cosine) of a number.
- * @param x A numeric expression.
- */
-export const acos = liftRet(Math.acos);
+    /**
+     * Returns the tangent of an angle.
+     * @param x An Angle
+     */
+    static tan = liftUnary(tan);
 
-/**
- * Returns the arctangent of a number.
- * @param x A numeric expression.
- */
-export const atan = liftRet(Math.atan);
+    /**
+     * Returns the arcsine of a number.
+     * @param x A numeric expression.
+     */
+    static asin = liftRet(asin);
 
-/**
- * Returns the angle from the X axis to a point.
- *
- * @param x A numeric expression representing the cartesian x-coordinate.
- * @param y A numeric expression representing the cartesian y-coordinate.
- */
-export function atan2(x: number, y: number): Angle {
-  return radians(Math.atan2(x, y));
+    /**
+     * Returns the arc cosine (or inverse cosine) of a number.
+     * @param x A numeric expression.
+     */
+    static acos = liftRet(acos);
+
+    /**
+     * Returns the arctangent of a number.
+     * @param x A numeric expression.
+     */
+    static atan = liftRet(atan);
+
+    /**
+     * Returns the angle from the X axis to a point.
+     *
+     * @param x A numeric expression representing the cartesian x-coordinate.
+     * @param y A numeric expression representing the cartesian y-coordinate.
+     */
+    static atan2(x: NumberType, y: NumberType): Angle<NumberType> {
+      // TODO: Ideally, we should not use toNative here
+      return WithValueType.radians(toNative(atan2(x, y)));
+    }
+  }
+
+  function liftRet(
+    f: (x: NumberType) => NumberType
+  ): (x: NumberType) => Angle<NumberType> {
+    // TODO: Ideally, we should not use toNative here
+    return x => WithValueType.radians(toNative(f(x)));
+  }
+
+  function liftUnary(
+    f: (x: NumberType) => NumberType
+  ): (x: Angle<NumberType>) => NumberType {
+    return x => f(x.in(WithValueType.radians).amount);
+  }
+
+  return WithValueType;
 }
 
-function liftRet(f: (x: number) => number): (x: number) => Angle {
-  return x => radians(f(x));
-}
-
-function liftUnary(f: (x: number) => number): (x: Angle) => number {
-  return x => f(x.in(radians).amount);
-}
+export const {radians, degrees, turns, sin, cos, tan, asin, acos, atan, atan2} =
+  withValueType(NativeArithmetic);

--- a/src/angle/index.ts
+++ b/src/angle/index.ts
@@ -1,12 +1,17 @@
 import * as dimension from './dimension';
 import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Geometric, NativeGeometric} from '../geometric';
 import {Quantity, makeUnitFactory} from '../unit';
 
 export type Angle<NumberType = number> = Quantity<NumberType, dimension.Angle>;
 
-export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+export function withValueType<NumberType>(
+  arithmetic: Arithmetic<NumberType>,
+  geometric: Geometric<NumberType>
+) {
   const {makeUnit} = makeUnitFactory(arithmetic);
-  const {toNative, sin, cos, tan, asin, acos, atan, atan2} = arithmetic;
+  const {toNative} = arithmetic;
+  const {sin, cos, tan, asin, acos, atan, atan2} = geometric;
 
   class WithValueType {
     private constructor() {}
@@ -87,4 +92,4 @@ export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
 }
 
 export const {radians, degrees, turns, sin, cos, tan, asin, acos, atan, atan2} =
-  withValueType(NativeArithmetic);
+  withValueType(NativeArithmetic, NativeGeometric);

--- a/src/angle/solid/index.ts
+++ b/src/angle/solid/index.ts
@@ -1,7 +1,10 @@
 import * as dimension from './dimension';
 import {Quantity, makeUnit} from '../../unit';
 
-export type SolidAngle = Quantity<dimension.SolidAngle>;
+export type SolidAngle<NumberType = number> = Quantity<
+  NumberType,
+  dimension.SolidAngle
+>;
 
 export const steradians = makeUnit('sr', dimension.SolidAngle);
 export const squareDegrees = steradians

--- a/src/angle/solid/index.ts
+++ b/src/angle/solid/index.ts
@@ -1,12 +1,25 @@
 import * as dimension from './dimension';
-import {Quantity, makeUnit} from '../../unit';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
+import {Quantity, makeUnitFactory} from '../../unit';
+import {withValueType as scalarWithValueType} from '../../scalar';
 
 export type SolidAngle<NumberType = number> = Quantity<
   NumberType,
   dimension.SolidAngle
 >;
 
-export const steradians = makeUnit('sr', dimension.SolidAngle);
-export const squareDegrees = steradians
-  .times((Math.PI / 180) ** 2)
-  .withSymbol('deg²');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
+  const {scalar} = scalarWithValueType(arithmetic);
+
+  return class WithValueType {
+    private constructor() {}
+
+    static steradians = makeUnit('sr', dimension.SolidAngle);
+    static squareDegrees = WithValueType.steradians
+      // TODO: Ideally, we should be able to give NumberType | number as a parameter for functions like times
+      .times(scalar(Math.PI).per(180).cubed().valueOf())
+      .withSymbol('deg²');
+  };
+}
+export const {steradians, squareDegrees} = withValueType(NativeArithmetic);

--- a/src/angle/solid/index.ts
+++ b/src/angle/solid/index.ts
@@ -17,7 +17,6 @@ export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
 
     static steradians = makeUnit('sr', dimension.SolidAngle);
     static squareDegrees = WithValueType.steradians
-      // TODO: Ideally, we should be able to give NumberType | number as a parameter for functions like times
       .times(scalar(Math.PI).per(180).cubed().valueOf())
       .withSymbol('deg²');
   };

--- a/src/area/index.ts
+++ b/src/area/index.ts
@@ -1,14 +1,26 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {meters} from '../length';
+import {withValueType as lengthWithValueType} from '../length';
 
 /** A quantity of area. */
 export type Area<NumberType = number> = Quantity<NumberType, dimension.Area>;
 
-/**
- * The square meter, symbol `m²`, is the SI unit of area. All other units in
- * this module are defined as scaled values of the square meter.
- */
-export const squareMeters: Unit<number, dimension.Area> = meters
-  .squared()
-  .withSymbol('m²');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters} = lengthWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The square meter, symbol `m²`, is the SI unit of area. All other units in
+     * this module are defined as scaled values of the square meter.
+     */
+    static squareMeters: Unit<NumberType, dimension.Area> = meters
+      .squared()
+      .withSymbol('m²');
+  }
+  return WithValueType;
+}
+
+export const {squareMeters} = withValueType(NativeArithmetic);

--- a/src/area/index.ts
+++ b/src/area/index.ts
@@ -3,12 +3,12 @@ import {Quantity, Unit} from '../unit';
 import {meters} from '../length';
 
 /** A quantity of area. */
-export type Area = Quantity<dimension.Area>;
+export type Area<NumberType = number> = Quantity<NumberType, dimension.Area>;
 
 /**
  * The square meter, symbol `m²`, is the SI unit of area. All other units in
  * this module are defined as scaled values of the square meter.
  */
-export const squareMeters: Unit<dimension.Area> = meters
+export const squareMeters: Unit<number, dimension.Area> = meters
   .squared()
   .withSymbol('m²');

--- a/src/arithmetic.ts
+++ b/src/arithmetic.ts
@@ -1,0 +1,44 @@
+export interface Arithmetic<NumberType> {
+  fromNative(value: number): NumberType;
+  toNative(value: NumberType): number;
+  add(left: NumberType, right: NumberType): NumberType;
+  sub(left: NumberType, right: NumberType): NumberType;
+  mul(left: NumberType, right: NumberType): NumberType;
+  div(left: NumberType, right: NumberType): NumberType;
+  pow(base: NumberType, exponent: NumberType): NumberType;
+  abs(value: NumberType): NumberType;
+  // 1 => left > right
+  // 0 => left === 0
+  // -1 => left < right
+  compare(left: NumberType, right: NumberType): number;
+}
+
+export const NativeArithmetic: Arithmetic<number> = {
+  fromNative: function (value: number): number {
+    return value;
+  },
+  toNative: function (value: number): number {
+    return value;
+  },
+  add: function (left: number, right: number): number {
+    return left + right;
+  },
+  sub: function (left: number, right: number): number {
+    return left - right;
+  },
+  mul: function (left: number, right: number): number {
+    return left * right;
+  },
+  div: function (left: number, right: number): number {
+    return left / right;
+  },
+  pow: function (base: number, exponent: number): number {
+    return base ** exponent;
+  },
+  abs: function (value: number): number {
+    return Math.abs(value);
+  },
+  compare: function (left: number, right: number): number {
+    return left - right;
+  }
+};

--- a/src/arithmetic.ts
+++ b/src/arithmetic.ts
@@ -1,3 +1,15 @@
+/**
+ * An arithmetic representation of a particular number type.
+ *
+ * The library is using by default the native number of JavaScript.
+ * As we know, it is not precise, and could lead to a calculation error.
+ * The most infamous example being (0.1 + 0.2).
+ *
+ * By implementing this interface, you will be able to write your own
+ * implementation of the arithmetic.
+ *
+ * For instance, you could implement it using [decimal.js]{@link https://github.com/MikeMcl/decimal.js}.
+ */
 export interface Arithmetic<NumberType> {
   fromNative(value: number): NumberType;
   toNative(value: NumberType): number;
@@ -11,17 +23,12 @@ export interface Arithmetic<NumberType> {
   // 0 => left === 0
   // -1 => left < right
   compare(left: NumberType, right: NumberType): number;
-
-  // Needed for the calculation of angles
-  sin(value: NumberType): NumberType;
-  cos(value: NumberType): NumberType;
-  tan(value: NumberType): NumberType;
-  asin(value: NumberType): NumberType;
-  acos(value: NumberType): NumberType;
-  atan(value: NumberType): NumberType;
-  atan2(left: NumberType, right: NumberType): NumberType;
 }
 
+/**
+ * Default implementation of the arithmetic interface
+ * based on the native number of JavaScript.
+ */
 export const NativeArithmetic: Arithmetic<number> = {
   fromNative: function (value: number): number {
     return value;
@@ -49,26 +56,5 @@ export const NativeArithmetic: Arithmetic<number> = {
   },
   compare: function (left: number, right: number): number {
     return left - right;
-  },
-  sin: function (value: number): number {
-    return Math.sin(value);
-  },
-  cos: function (value: number): number {
-    return Math.cos(value);
-  },
-  tan: function (value: number): number {
-    return Math.tan(value);
-  },
-  asin: function (value: number): number {
-    return Math.asin(value);
-  },
-  acos: function (value: number): number {
-    return Math.acos(value);
-  },
-  atan: function (value: number): number {
-    return Math.atan(value);
-  },
-  atan2: function (left: number, right: number): number {
-    return Math.atan2(left, right);
   }
 };

--- a/src/arithmetic.ts
+++ b/src/arithmetic.ts
@@ -11,6 +11,15 @@ export interface Arithmetic<NumberType> {
   // 0 => left === 0
   // -1 => left < right
   compare(left: NumberType, right: NumberType): number;
+
+  // Needed for the calculation of angles
+  sin(value: NumberType): NumberType;
+  cos(value: NumberType): NumberType;
+  tan(value: NumberType): NumberType;
+  asin(value: NumberType): NumberType;
+  acos(value: NumberType): NumberType;
+  atan(value: NumberType): NumberType;
+  atan2(left: NumberType, right: NumberType): NumberType;
 }
 
 export const NativeArithmetic: Arithmetic<number> = {
@@ -40,5 +49,26 @@ export const NativeArithmetic: Arithmetic<number> = {
   },
   compare: function (left: number, right: number): number {
     return left - right;
+  },
+  sin: function (value: number): number {
+    return Math.sin(value);
+  },
+  cos: function (value: number): number {
+    return Math.cos(value);
+  },
+  tan: function (value: number): number {
+    return Math.tan(value);
+  },
+  asin: function (value: number): number {
+    return Math.asin(value);
+  },
+  acos: function (value: number): number {
+    return Math.acos(value);
+  },
+  atan: function (value: number): number {
+    return Math.atan(value);
+  },
+  atan2: function (left: number, right: number): number {
+    return Math.atan2(left, right);
   }
 };

--- a/src/electric/capacitance/index.ts
+++ b/src/electric/capacitance/index.ts
@@ -6,10 +6,13 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of electrical capacitance. */
-export type Capacitance = Quantity<dimension.Capacitance>;
+export type Capacitance<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Capacitance
+>;
 
 /** The farad, symbol `F`, is the SI unit for electrical capacitance. */
-export const farads: Unit<dimension.Capacitance> = seconds
+export const farads: Unit<number, dimension.Capacitance> = seconds
   .squared()
   .squared()
   .times(amperes.squared())

--- a/src/electric/capacitance/index.ts
+++ b/src/electric/capacitance/index.ts
@@ -1,9 +1,10 @@
 import * as dimension from './dimension';
-import {Quantity, SiPrefix, Unit} from '../../unit';
-import {amperes} from '../current';
-import {kilograms} from '../../mass';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
+import {Quantity, Unit} from '../../unit';
+import {withValueType as currentWithValueType} from '../current';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of electrical capacitance. */
 export type Capacitance<NumberType = number> = Quantity<
@@ -11,15 +12,31 @@ export type Capacitance<NumberType = number> = Quantity<
   dimension.Capacitance
 >;
 
-/** The farad, symbol `F`, is the SI unit for electrical capacitance. */
-export const farads: Unit<number, dimension.Capacitance> = seconds
-  .squared()
-  .squared()
-  .times(amperes.squared())
-  .per(kilograms)
-  .per(meters.squared())
-  .withSymbol('F');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
 
-export const [microfarads, nanofarads, picofarads] = (
-  ['μ', 'n', 'p'] as SiPrefix[]
-).map(x => farads.withSiPrefix(x));
+  class WithValueType {
+    private constructor() {}
+
+    /** The farad, symbol `F`, is the SI unit for electrical capacitance. */
+    static farads: Unit<NumberType, dimension.Capacitance> = seconds
+      .squared()
+      .squared()
+      .times(amperes.squared())
+      .per(kilograms)
+      .per(meters.squared())
+      .withSymbol('F');
+
+    static microfarads = WithValueType.farads.withSiPrefix('μ');
+    static nanofarads = WithValueType.farads.withSiPrefix('n');
+    static picofarads = WithValueType.farads.withSiPrefix('p');
+  }
+
+  return WithValueType;
+}
+
+export const {farads, microfarads, nanofarads, picofarads} =
+  withValueType(NativeArithmetic);

--- a/src/electric/charge/index.ts
+++ b/src/electric/charge/index.ts
@@ -1,7 +1,8 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../current';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../current';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of electric charge. */
 export type Charge<NumberType = number> = Quantity<
@@ -9,7 +10,20 @@ export type Charge<NumberType = number> = Quantity<
   dimension.Charge
 >;
 
-/** The coulomb, symbol `C`, is the SI unit for electric charge. */
-export const coulombs: Unit<number, dimension.Charge> = amperes
-  .times(seconds)
-  .withSymbol('C');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The coulomb, symbol `C`, is the SI unit for electric charge. */
+    static coulombs: Unit<NumberType, dimension.Charge> = amperes
+      .times(seconds)
+      .withSymbol('C');
+  }
+
+  return WithValueType;
+}
+
+export const {coulombs} = withValueType(NativeArithmetic);

--- a/src/electric/charge/index.ts
+++ b/src/electric/charge/index.ts
@@ -4,9 +4,12 @@ import {amperes} from '../current';
 import {seconds} from '../../time';
 
 /** A quantity of electric charge. */
-export type Charge = Quantity<dimension.Charge>;
+export type Charge<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Charge
+>;
 
 /** The coulomb, symbol `C`, is the SI unit for electric charge. */
-export const coulombs: Unit<dimension.Charge> = amperes
+export const coulombs: Unit<number, dimension.Charge> = amperes
   .times(seconds)
   .withSymbol('C');

--- a/src/electric/conductance/index.ts
+++ b/src/electric/conductance/index.ts
@@ -1,9 +1,10 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../current';
-import {kilograms} from '../../mass';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../current';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of electrical conductance. */
 export type Conductance<NumberType = number> = Quantity<
@@ -11,10 +12,25 @@ export type Conductance<NumberType = number> = Quantity<
   dimension.Conductance
 >;
 
-/** The siemens, symbol `Ω`, is the SI unit for electrical conductance. */
-export const ohms: Unit<number, dimension.Conductance> = seconds
-  .cubed()
-  .times(amperes.squared())
-  .per(kilograms)
-  .per(meters.squared())
-  .withSymbol('S');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The siemens, symbol `S`, is the SI unit for electrical conductance. */
+    static siemens: Unit<NumberType, dimension.Conductance> = seconds
+      .cubed()
+      .times(amperes.squared())
+      .per(kilograms)
+      .per(meters.squared())
+      .withSymbol('S');
+  }
+
+  return WithValueType;
+}
+
+export const {siemens} = withValueType(NativeArithmetic);

--- a/src/electric/conductance/index.ts
+++ b/src/electric/conductance/index.ts
@@ -6,10 +6,13 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of electrical conductance. */
-export type Conductance = Quantity<dimension.Conductance>;
+export type Conductance<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Conductance
+>;
 
 /** The siemens, symbol `Ω`, is the SI unit for electrical conductance. */
-export const ohms: Unit<dimension.Conductance> = seconds
+export const ohms: Unit<number, dimension.Conductance> = seconds
   .cubed()
   .times(amperes.squared())
   .per(kilograms)

--- a/src/electric/current/index.ts
+++ b/src/electric/current/index.ts
@@ -1,5 +1,6 @@
 import * as dimension from './dimension';
-import {Quantity, makeUnit} from '../../unit';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
+import {Quantity, makeUnitFactory} from '../../unit';
 
 /** A quantity of electric current. */
 export type Current<NumberType = number> = Quantity<
@@ -7,8 +8,20 @@ export type Current<NumberType = number> = Quantity<
   dimension.Current
 >;
 
-/**
- * The ampere, symbol `A`, is the SI base unit of electric current. All other
- * units in this module are defined as scaled values of the ampere.
- */
-export const amperes = makeUnit('A', dimension.Current);
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The ampere, symbol `A`, is the SI base unit of electric current. All other
+     * units in this module are defined as scaled values of the ampere.
+     */
+    static amperes = makeUnit('A', dimension.Current);
+  }
+
+  return WithValueType;
+}
+
+export const {amperes} = withValueType(NativeArithmetic);

--- a/src/electric/current/index.ts
+++ b/src/electric/current/index.ts
@@ -2,7 +2,10 @@ import * as dimension from './dimension';
 import {Quantity, makeUnit} from '../../unit';
 
 /** A quantity of electric current. */
-export type Current = Quantity<dimension.Current>;
+export type Current<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Current
+>;
 
 /**
  * The ampere, symbol `A`, is the SI base unit of electric current. All other

--- a/src/electric/inductance/index.ts
+++ b/src/electric/inductance/index.ts
@@ -1,9 +1,10 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../current';
-import {kilograms} from '../../mass';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../current';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of electrical inductance. */
 export type Inductance<NumberType = number> = Quantity<
@@ -11,9 +12,24 @@ export type Inductance<NumberType = number> = Quantity<
   dimension.Inductance
 >;
 
-/** The henry, symbol `H`, is the SI unit for electrical inductance. */
-export const henries: Unit<number, dimension.Inductance> = kilograms
-  .times(meters.squared())
-  .per(seconds.squared())
-  .per(amperes.squared())
-  .withSymbol('H');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The henry, symbol `H`, is the SI unit for electrical inductance. */
+    static henries: Unit<NumberType, dimension.Inductance> = kilograms
+      .times(meters.squared())
+      .per(seconds.squared())
+      .per(amperes.squared())
+      .withSymbol('H');
+  }
+
+  return WithValueType;
+}
+
+export const {henries} = withValueType(NativeArithmetic);

--- a/src/electric/inductance/index.ts
+++ b/src/electric/inductance/index.ts
@@ -6,10 +6,13 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of electrical inductance. */
-export type Inductance = Quantity<dimension.Inductance>;
+export type Inductance<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Inductance
+>;
 
 /** The henry, symbol `H`, is the SI unit for electrical inductance. */
-export const henries: Unit<dimension.Inductance> = kilograms
+export const henries: Unit<number, dimension.Inductance> = kilograms
   .times(meters.squared())
   .per(seconds.squared())
   .per(amperes.squared())

--- a/src/electric/resistance/index.ts
+++ b/src/electric/resistance/index.ts
@@ -6,10 +6,13 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of electrical resistance. */
-export type Resistance = Quantity<dimension.Resistance>;
+export type Resistance<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Resistance
+>;
 
 /** The ohm, symbol `Ω`, is the SI unit for electrical resistance. */
-export const ohms: Unit<dimension.Resistance> = kilograms
+export const ohms: Unit<number, dimension.Resistance> = kilograms
   .times(meters.squared())
   .per(seconds.cubed())
   .per(amperes.squared())

--- a/src/electric/resistance/index.ts
+++ b/src/electric/resistance/index.ts
@@ -1,9 +1,10 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../current';
-import {kilograms} from '../../mass';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../current';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of electrical resistance. */
 export type Resistance<NumberType = number> = Quantity<
@@ -11,9 +12,24 @@ export type Resistance<NumberType = number> = Quantity<
   dimension.Resistance
 >;
 
-/** The ohm, symbol `Ω`, is the SI unit for electrical resistance. */
-export const ohms: Unit<number, dimension.Resistance> = kilograms
-  .times(meters.squared())
-  .per(seconds.cubed())
-  .per(amperes.squared())
-  .withSymbol('Ω');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The ohm, symbol `Ω`, is the SI unit for electrical resistance. */
+    static ohms: Unit<NumberType, dimension.Resistance> = kilograms
+      .times(meters.squared())
+      .per(seconds.cubed())
+      .per(amperes.squared())
+      .withSymbol('Ω');
+  }
+
+  return WithValueType;
+}
+
+export const {ohms} = withValueType(NativeArithmetic);

--- a/src/electric/voltage/index.ts
+++ b/src/electric/voltage/index.ts
@@ -6,10 +6,13 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of voltage. */
-export type Voltage = Quantity<dimension.Voltage>;
+export type Voltage<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Voltage
+>;
 
 /** The volt, symbol `V`, is the SI unit for voltage. */
-export const volts: Unit<dimension.Voltage> = kilograms
+export const volts: Unit<number, dimension.Voltage> = kilograms
   .times(meters.squared())
   .per(seconds.cubed())
   .per(amperes)

--- a/src/electric/voltage/index.ts
+++ b/src/electric/voltage/index.ts
@@ -1,9 +1,10 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../current';
-import {kilograms} from '../../mass';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../current';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of voltage. */
 export type Voltage<NumberType = number> = Quantity<
@@ -11,9 +12,24 @@ export type Voltage<NumberType = number> = Quantity<
   dimension.Voltage
 >;
 
-/** The volt, symbol `V`, is the SI unit for voltage. */
-export const volts: Unit<number, dimension.Voltage> = kilograms
-  .times(meters.squared())
-  .per(seconds.cubed())
-  .per(amperes)
-  .withSymbol('V');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The volt, symbol `V`, is the SI unit for voltage. */
+    static volts: Unit<NumberType, dimension.Voltage> = kilograms
+      .times(meters.squared())
+      .per(seconds.cubed())
+      .per(amperes)
+      .withSymbol('V');
+  }
+
+  return WithValueType;
+}
+
+export const {volts} = withValueType(NativeArithmetic);

--- a/src/energy/index.ts
+++ b/src/energy/index.ts
@@ -5,10 +5,13 @@ import {meters} from '../length';
 import {seconds} from '../time';
 
 /** A quantity of energy. */
-export type Energy = Quantity<dimension.Energy>;
+export type Energy<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Energy
+>;
 
 /** The joule, symbol `J`, is the SI unit for energy. */
-export const joules: Unit<dimension.Energy> = kilograms
+export const joules: Unit<number, dimension.Energy> = kilograms
   .times(meters.squared())
   .per(seconds.squared())
   .withSymbol('J');

--- a/src/energy/index.ts
+++ b/src/energy/index.ts
@@ -1,8 +1,9 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {kilograms} from '../mass';
-import {meters} from '../length';
-import {seconds} from '../time';
+import {withValueType as lengthWithValueType} from '../length';
+import {withValueType as massWithValueType} from '../mass';
+import {withValueType as timeWithValueType} from '../time';
 
 /** A quantity of energy. */
 export type Energy<NumberType = number> = Quantity<
@@ -10,8 +11,22 @@ export type Energy<NumberType = number> = Quantity<
   dimension.Energy
 >;
 
-/** The joule, symbol `J`, is the SI unit for energy. */
-export const joules: Unit<number, dimension.Energy> = kilograms
-  .times(meters.squared())
-  .per(seconds.squared())
-  .withSymbol('J');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The joule, symbol `J`, is the SI unit for energy. */
+    static joules: Unit<NumberType, dimension.Energy> = kilograms
+      .times(meters.squared())
+      .per(seconds.squared())
+      .withSymbol('J');
+  }
+
+  return WithValueType;
+}
+
+export const {joules} = withValueType(NativeArithmetic);

--- a/src/force/index.ts
+++ b/src/force/index.ts
@@ -5,10 +5,10 @@ import {meters} from '../length';
 import {seconds} from '../time';
 
 /** A quantity of force. */
-export type Force = Quantity<dimension.Force>;
+export type Force<NumberType = number> = Quantity<NumberType, dimension.Force>;
 
 /** The newton, symbol `N`, is the SI unit for force. */
-export const newtons: Unit<dimension.Force> = kilograms
+export const newtons: Unit<number, dimension.Force> = kilograms
   .times(meters)
   .per(seconds.squared())
   .withSymbol('N');

--- a/src/force/index.ts
+++ b/src/force/index.ts
@@ -1,14 +1,29 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {kilograms} from '../mass';
-import {meters} from '../length';
-import {seconds} from '../time';
+import {withValueType as lengthWithValueType} from '../length';
+import {withValueType as massWithValueType} from '../mass';
+import {withValueType as timeWithValueType} from '../time';
 
 /** A quantity of force. */
 export type Force<NumberType = number> = Quantity<NumberType, dimension.Force>;
 
-/** The newton, symbol `N`, is the SI unit for force. */
-export const newtons: Unit<number, dimension.Force> = kilograms
-  .times(meters)
-  .per(seconds.squared())
-  .withSymbol('N');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {kilograms} = massWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The newton, symbol `N`, is the SI unit for force. */
+    static newtons: Unit<NumberType, dimension.Force> = kilograms
+      .times(meters)
+      .per(seconds.squared())
+      .withSymbol('N');
+  }
+
+  return WithValueType;
+}
+
+export const {newtons} = withValueType(NativeArithmetic);

--- a/src/frequency/index.ts
+++ b/src/frequency/index.ts
@@ -3,9 +3,12 @@ import {Quantity, Unit} from '../unit';
 import {seconds} from '../time';
 
 /** A quantity of frequency. */
-export type Frequency = Quantity<dimension.Frequency>;
+export type Frequency<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Frequency
+>;
 
 /** The hertz, symbol `Hz`, is the SI unit for frequency. */
-export const hertz: Unit<dimension.Frequency> = seconds
+export const hertz: Unit<number, dimension.Frequency> = seconds
   .reciprocal()
   .withSymbol('Hz');

--- a/src/frequency/index.ts
+++ b/src/frequency/index.ts
@@ -1,6 +1,7 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {seconds} from '../time';
+import {withValueType as timeWithValueType} from '../time';
 
 /** A quantity of frequency. */
 export type Frequency<NumberType = number> = Quantity<
@@ -8,7 +9,19 @@ export type Frequency<NumberType = number> = Quantity<
   dimension.Frequency
 >;
 
-/** The hertz, symbol `Hz`, is the SI unit for frequency. */
-export const hertz: Unit<number, dimension.Frequency> = seconds
-  .reciprocal()
-  .withSymbol('Hz');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The hertz, symbol `Hz`, is the SI unit for frequency. */
+    static hertz: Unit<NumberType, dimension.Frequency> = seconds
+      .reciprocal()
+      .withSymbol('Hz');
+  }
+
+  return WithValueType;
+}
+
+export const {hertz} = withValueType(NativeArithmetic);

--- a/src/geometric.ts
+++ b/src/geometric.ts
@@ -1,0 +1,49 @@
+/**
+ * A geometric representation of a particular type number.
+ *
+ * The Planar Angles need access to geometric functions.
+ * Similar to Arithmetic interface, we can provide an implementation
+ * that is not based on the native Math functions of JavaScript.
+ *
+ * By implementing this interface, you will be able to write your own
+ * implementation of the geometric functions.
+ * The implementation will need to have the same number type as your arithmetic
+ * implementation.
+ */
+export interface Geometric<NumberType> {
+  sin(value: NumberType): NumberType;
+  cos(value: NumberType): NumberType;
+  tan(value: NumberType): NumberType;
+  asin(value: NumberType): NumberType;
+  acos(value: NumberType): NumberType;
+  atan(value: NumberType): NumberType;
+  atan2(left: NumberType, right: NumberType): NumberType;
+}
+
+/**
+ * Default implementation of the geometric interface
+ * based on the native Math functions of JavaScript.
+ */
+export const NativeGeometric: Geometric<number> = {
+  sin: function (value: number): number {
+    return Math.sin(value);
+  },
+  cos: function (value: number): number {
+    return Math.cos(value);
+  },
+  tan: function (value: number): number {
+    return Math.tan(value);
+  },
+  asin: function (value: number): number {
+    return Math.asin(value);
+  },
+  acos: function (value: number): number {
+    return Math.acos(value);
+  },
+  atan: function (value: number): number {
+    return Math.atan(value);
+  },
+  atan2: function (left: number, right: number): number {
+    return Math.atan2(left, right);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './arithmetic';
 export * from './dimension';
 export * from './exponent';
+export * from './geometric';
 export * from './unit';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './arithmetic';
 export * from './dimension';
 export * from './exponent';
 export * from './unit';

--- a/src/length/index.ts
+++ b/src/length/index.ts
@@ -2,7 +2,10 @@ import * as dimension from './dimension';
 import {Quantity, SiPrefix, makeUnit} from '../unit';
 
 /** A quantity of length. */
-export type Length = Quantity<dimension.Length>;
+export type Length<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Length
+>;
 
 /**
  * The meter, symbol `m`, is the SI base unit of length. All other units in
@@ -28,8 +31,8 @@ export const microns = micrometers;
 
 // Imperial units
 export const yards = meters.times(0.9144).withSymbol('yd');
-export const feet = yards.times(1 / 3).withSymbol('ft');
-export const inches = feet.times(1 / 12).withSymbol('in');
+export const feet = yards.per(3).withSymbol('ft');
+export const inches = feet.per(12).withSymbol('in');
 export const chains = yards.times(22).withSymbol('ch');
 export const furlongs = chains.times(10).withSymbol('fur');
 export const miles = furlongs.times(8).withSymbol('mi');

--- a/src/length/index.ts
+++ b/src/length/index.ts
@@ -1,5 +1,6 @@
 import * as dimension from './dimension';
-import {Quantity, SiPrefix, makeUnit} from '../unit';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Quantity, makeUnitFactory} from '../unit';
 
 /** A quantity of length. */
 export type Length<NumberType = number> = Quantity<
@@ -7,39 +8,69 @@ export type Length<NumberType = number> = Quantity<
   dimension.Length
 >;
 
-/**
- * The meter, symbol `m`, is the SI base unit of length. All other units in
- * this module are defined as scaled values of the meter.
- */
-export const meters = makeUnit('m', dimension.Length);
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
 
-export const [
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The meter, symbol `m`, is the SI base unit of length. All other units in
+     * this module are defined as scaled values of the meter.
+     */
+    static meters = makeUnit('m', dimension.Length);
+    static kilometers = WithValueType.meters.withSiPrefix('k');
+    static centimeters = WithValueType.meters.withSiPrefix('c');
+    static millimeters = WithValueType.meters.withSiPrefix('m');
+    static micrometers = WithValueType.meters.withSiPrefix('μ');
+    static nanometers = WithValueType.meters.withSiPrefix('n');
+    static picometers = WithValueType.meters.withSiPrefix('p');
+    static femtometers = WithValueType.meters.withSiPrefix('f');
+
+    static fermi = WithValueType.femtometers;
+    static angstroms = WithValueType.meters.times(1e-10).withSymbol('Å');
+    static microns = WithValueType.micrometers;
+
+    // Imperial units
+    static yards = WithValueType.meters.times(0.9144).withSymbol('yd');
+    static feet = WithValueType.yards.per(3).withSymbol('ft');
+    static inches = WithValueType.feet.per(12).withSymbol('in');
+    static chains = WithValueType.yards.times(22).withSymbol('ch');
+    static furlongs = WithValueType.chains.times(10).withSymbol('fur');
+    static miles = WithValueType.furlongs.times(8).withSymbol('mi');
+
+    // Marine units
+    static fathoms = WithValueType.yards.times(2).withSymbol('ftm');
+    static nauticalMiles = WithValueType.meters.times(1852).withSymbol('M');
+
+    // Astronomical Units
+    static astronomicalUnits = WithValueType.meters
+      .times(149597870700)
+      .withSymbol('au');
+  }
+
+  return WithValueType;
+}
+
+export const {
+  meters,
   kilometers,
   centimeters,
   millimeters,
   micrometers,
   nanometers,
   picometers,
-  femtometers
-] = (['k', 'c', 'm', 'μ', 'n', 'p', 'f'] as SiPrefix[]).map(x =>
-  meters.withSiPrefix(x)
-);
-
-export const fermi = femtometers;
-export const angstroms = meters.times(1e-10).withSymbol('Å');
-export const microns = micrometers;
-
-// Imperial units
-export const yards = meters.times(0.9144).withSymbol('yd');
-export const feet = yards.per(3).withSymbol('ft');
-export const inches = feet.per(12).withSymbol('in');
-export const chains = yards.times(22).withSymbol('ch');
-export const furlongs = chains.times(10).withSymbol('fur');
-export const miles = furlongs.times(8).withSymbol('mi');
-
-// Marine units
-export const fathoms = yards.times(2).withSymbol('ftm');
-export const nauticalMiles = meters.times(1852).withSymbol('M');
-
-// Astronomical Units
-export const astronomicalUnits = meters.times(149597870700).withSymbol('au');
+  femtometers,
+  fermi,
+  angstroms,
+  microns,
+  yards,
+  feet,
+  inches,
+  chains,
+  furlongs,
+  miles,
+  fathoms,
+  nauticalMiles,
+  astronomicalUnits
+} = withValueType(NativeArithmetic);

--- a/src/luminous/flux/index.ts
+++ b/src/luminous/flux/index.ts
@@ -4,9 +4,9 @@ import {candelas} from '../intensity';
 import {steradians} from '../../angle/solid';
 
 /** A quantity of luminous flux. */
-export type Flux = Quantity<dimension.Flux>;
+export type Flux<NumberType = number> = Quantity<NumberType, dimension.Flux>;
 
 /** The lumen, symbol `lm`, is the SI unit for luminous flux. */
-export const lumens: Unit<dimension.Flux> = candelas
+export const lumens: Unit<number, dimension.Flux> = candelas
   .times(steradians)
   .withSymbol('lm');

--- a/src/luminous/flux/index.ts
+++ b/src/luminous/flux/index.ts
@@ -1,12 +1,26 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {candelas} from '../intensity';
-import {steradians} from '../../angle/solid';
+import {withValueType as intensityWithValueType} from '../intensity';
+import {withValueType as solidAngleWithValueType} from '../../angle/solid';
 
 /** A quantity of luminous flux. */
 export type Flux<NumberType = number> = Quantity<NumberType, dimension.Flux>;
 
-/** The lumen, symbol `lm`, is the SI unit for luminous flux. */
-export const lumens: Unit<number, dimension.Flux> = candelas
-  .times(steradians)
-  .withSymbol('lm');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {candelas} = intensityWithValueType(arithmetic);
+  const {steradians} = solidAngleWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The lumen, symbol `lm`, is the SI unit for luminous flux. */
+    static lumens: Unit<NumberType, dimension.Flux> = candelas
+      .times(steradians)
+      .withSymbol('lm');
+  }
+
+  return WithValueType;
+}
+
+export const {lumens} = withValueType(NativeArithmetic);

--- a/src/luminous/illuminance/index.ts
+++ b/src/luminous/illuminance/index.ts
@@ -1,7 +1,8 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {candelas} from '../intensity';
-import {meters} from '../../length';
+import {withValueType as intensityWithValueType} from '../intensity';
+import {withValueType as lengthWithValueType} from '../../length';
 
 /** A quantity of illuminance. */
 export type Illuminance<NumberType = number> = Quantity<
@@ -9,7 +10,20 @@ export type Illuminance<NumberType = number> = Quantity<
   dimension.Illuminance
 >;
 
-/** The lux, symbol `lx`, is the SI unit for illuminance. */
-export const lux: Unit<number, dimension.Illuminance> = candelas
-  .per(meters.squared())
-  .withSymbol('lx');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {candelas} = intensityWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The lux, symbol `lx`, is the SI unit for illuminance. */
+    static lux: Unit<NumberType, dimension.Illuminance> = candelas
+      .per(meters.squared())
+      .withSymbol('lx');
+  }
+
+  return WithValueType;
+}
+
+export const {lux} = withValueType(NativeArithmetic);

--- a/src/luminous/illuminance/index.ts
+++ b/src/luminous/illuminance/index.ts
@@ -4,9 +4,12 @@ import {candelas} from '../intensity';
 import {meters} from '../../length';
 
 /** A quantity of illuminance. */
-export type Illuminance = Quantity<dimension.Illuminance>;
+export type Illuminance<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Illuminance
+>;
 
 /** The lux, symbol `lx`, is the SI unit for illuminance. */
-export const lux: Unit<dimension.Illuminance> = candelas
+export const lux: Unit<number, dimension.Illuminance> = candelas
   .per(meters.squared())
   .withSymbol('lx');

--- a/src/luminous/intensity/index.ts
+++ b/src/luminous/intensity/index.ts
@@ -1,5 +1,6 @@
 import * as dimension from './dimension';
-import {Quantity, makeUnit} from '../../unit';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
+import {Quantity, makeUnitFactory} from '../../unit';
 
 /** A quantity of luminous intensity. */
 export type Intensity<NumberType = number> = Quantity<
@@ -7,8 +8,20 @@ export type Intensity<NumberType = number> = Quantity<
   dimension.Intensity
 >;
 
-/**
- * The candela, symbol `cd`, is the SI base unit of luminous intensity. All
- * other units in this module are defined as scaled values of the candela.
- */
-export const candelas = makeUnit('cd', dimension.Intensity);
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The candela, symbol `cd`, is the SI base unit of luminous intensity. All
+     * other units in this module are defined as scaled values of the candela.
+     */
+    static candelas = makeUnit('cd', dimension.Intensity);
+  }
+
+  return WithValueType;
+}
+
+export const {candelas} = withValueType(NativeArithmetic);

--- a/src/luminous/intensity/index.ts
+++ b/src/luminous/intensity/index.ts
@@ -2,7 +2,10 @@ import * as dimension from './dimension';
 import {Quantity, makeUnit} from '../../unit';
 
 /** A quantity of luminous intensity. */
-export type Intensity = Quantity<dimension.Intensity>;
+export type Intensity<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Intensity
+>;
 
 /**
  * The candela, symbol `cd`, is the SI base unit of luminous intensity. All

--- a/src/magnetic/flux/index.ts
+++ b/src/magnetic/flux/index.ts
@@ -1,16 +1,32 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../../electric/current';
-import {kilograms} from '../../mass';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../../electric/current';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of magnetic flux. */
 export type Flux<NumberType = number> = Quantity<NumberType, dimension.Flux>;
 
-/** The weber, symbol `Wb`, is the SI unit for magnetic flux. */
-export const webers: Unit<number, dimension.Flux> = kilograms
-  .times(meters.squared())
-  .per(seconds.squared())
-  .per(amperes)
-  .withSymbol('Wb');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The weber, symbol `Wb`, is the SI unit for magnetic flux. */
+    static webers: Unit<NumberType, dimension.Flux> = kilograms
+      .times(meters.squared())
+      .per(seconds.squared())
+      .per(amperes)
+      .withSymbol('Wb');
+  }
+
+  return WithValueType;
+}
+
+export const {webers} = withValueType(NativeArithmetic);

--- a/src/magnetic/flux/index.ts
+++ b/src/magnetic/flux/index.ts
@@ -6,10 +6,10 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of magnetic flux. */
-export type Flux = Quantity<dimension.Flux>;
+export type Flux<NumberType = number> = Quantity<NumberType, dimension.Flux>;
 
 /** The weber, symbol `Wb`, is the SI unit for magnetic flux. */
-export const webers: Unit<dimension.Flux> = kilograms
+export const webers: Unit<number, dimension.Flux> = kilograms
   .times(meters.squared())
   .per(seconds.squared())
   .per(amperes)

--- a/src/magnetic/induction/index.ts
+++ b/src/magnetic/induction/index.ts
@@ -5,10 +5,13 @@ import {kilograms} from '../../mass';
 import {seconds} from '../../time';
 
 /** A quantity of magnetic induction. */
-export type Induction = Quantity<dimension.Induction>;
+export type Induction<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Induction
+>;
 
 /** The tesla, symbol `T`, is the SI unit for magnetic induction. */
-export const teslas: Unit<dimension.Induction> = kilograms
+export const teslas: Unit<number, dimension.Induction> = kilograms
   .per(seconds.squared())
   .per(amperes)
   .withSymbol('T');

--- a/src/magnetic/induction/index.ts
+++ b/src/magnetic/induction/index.ts
@@ -1,8 +1,9 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {amperes} from '../../electric/current';
-import {kilograms} from '../../mass';
-import {seconds} from '../../time';
+import {withValueType as currentWithValueType} from '../../electric/current';
+import {withValueType as massWithValueType} from '../../mass';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of magnetic induction. */
 export type Induction<NumberType = number> = Quantity<
@@ -10,8 +11,22 @@ export type Induction<NumberType = number> = Quantity<
   dimension.Induction
 >;
 
-/** The tesla, symbol `T`, is the SI unit for magnetic induction. */
-export const teslas: Unit<number, dimension.Induction> = kilograms
-  .per(seconds.squared())
-  .per(amperes)
-  .withSymbol('T');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {amperes} = currentWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The tesla, symbol `T`, is the SI unit for magnetic induction. */
+    static teslas: Unit<NumberType, dimension.Induction> = kilograms
+      .per(seconds.squared())
+      .per(amperes)
+      .withSymbol('T');
+  }
+
+  return WithValueType;
+}
+
+export const {teslas} = withValueType(NativeArithmetic);

--- a/src/mass/index.ts
+++ b/src/mass/index.ts
@@ -1,13 +1,26 @@
 import * as dimension from './dimension';
-import {Quantity, makeUnit} from '../unit';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Quantity, makeUnitFactory} from '../unit';
 
 /** A quantity of mass. */
 export type Mass<NumberType = number> = Quantity<NumberType, dimension.Mass>;
 
-/**
- * The kilogram, symbol `kg` is the SI base unit of mass. All other units in
- * this module are defined as scaled values of the kilogram.
- */
-export const kilograms = makeUnit('kg', dimension.Mass);
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
 
-export const grams = kilograms.times(1e-3).withSymbol('g');
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The kilogram, symbol `kg` is the SI base unit of mass. All other units in
+     * this module are defined as scaled values of the kilogram.
+     */
+    static kilograms = makeUnit('kg', dimension.Mass);
+
+    static grams = WithValueType.kilograms.times(1e-3).withSymbol('g');
+  }
+
+  return WithValueType;
+}
+
+export const {kilograms, grams} = withValueType(NativeArithmetic);

--- a/src/mass/index.ts
+++ b/src/mass/index.ts
@@ -2,7 +2,7 @@ import * as dimension from './dimension';
 import {Quantity, makeUnit} from '../unit';
 
 /** A quantity of mass. */
-export type Mass = Quantity<dimension.Mass>;
+export type Mass<NumberType = number> = Quantity<NumberType, dimension.Mass>;
 
 /**
  * The kilogram, symbol `kg` is the SI base unit of mass. All other units in

--- a/src/power/index.ts
+++ b/src/power/index.ts
@@ -5,10 +5,10 @@ import {meters} from '../length';
 import {seconds} from '../time';
 
 /** A quantity of power. */
-export type Power = Quantity<dimension.Power>;
+export type Power<NumberType = number> = Quantity<NumberType, dimension.Power>;
 
 /** The watt, symbol `W`, is the SI unit for power. */
-export const watts: Unit<dimension.Power> = kilograms
+export const watts: Unit<number, dimension.Power> = kilograms
   .times(meters.squared())
   .per(seconds.cubed())
   .withSymbol('W');

--- a/src/power/index.ts
+++ b/src/power/index.ts
@@ -1,14 +1,29 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {kilograms} from '../mass';
-import {meters} from '../length';
-import {seconds} from '../time';
+import {withValueType as lengthWithValueType} from '../length';
+import {withValueType as massWithValueType} from '../mass';
+import {withValueType as timeWithValueType} from '../time';
 
 /** A quantity of power. */
 export type Power<NumberType = number> = Quantity<NumberType, dimension.Power>;
 
-/** The watt, symbol `W`, is the SI unit for power. */
-export const watts: Unit<number, dimension.Power> = kilograms
-  .times(meters.squared())
-  .per(seconds.cubed())
-  .withSymbol('W');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The watt, symbol `W`, is the SI unit for power. */
+    static watts: Unit<NumberType, dimension.Power> = kilograms
+      .times(meters.squared())
+      .per(seconds.cubed())
+      .withSymbol('W');
+  }
+
+  return WithValueType;
+}
+
+export const {watts} = withValueType(NativeArithmetic);

--- a/src/pressure/index.ts
+++ b/src/pressure/index.ts
@@ -5,10 +5,13 @@ import {meters} from '../length';
 import {seconds} from '../time';
 
 /** A quantity of pressure. */
-export type Pressure = Quantity<dimension.Pressure>;
+export type Pressure<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Pressure
+>;
 
 /** The pascal, symbol `Pa`, is the SI unit for force. */
-export const pascals: Unit<dimension.Pressure> = kilograms
+export const pascals: Unit<number, dimension.Pressure> = kilograms
   .per(meters)
   .per(seconds.squared())
   .withSymbol('Pa');

--- a/src/pressure/index.ts
+++ b/src/pressure/index.ts
@@ -1,8 +1,9 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {kilograms} from '../mass';
-import {meters} from '../length';
-import {seconds} from '../time';
+import {withValueType as lengthWithValueType} from '../length';
+import {withValueType as massWithValueType} from '../mass';
+import {withValueType as timeWithValueType} from '../time';
 
 /** A quantity of pressure. */
 export type Pressure<NumberType = number> = Quantity<
@@ -10,8 +11,22 @@ export type Pressure<NumberType = number> = Quantity<
   dimension.Pressure
 >;
 
-/** The pascal, symbol `Pa`, is the SI unit for force. */
-export const pascals: Unit<number, dimension.Pressure> = kilograms
-  .per(meters)
-  .per(seconds.squared())
-  .withSymbol('Pa');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters} = lengthWithValueType(arithmetic);
+  const {kilograms} = massWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The pascal, symbol `Pa`, is the SI unit for force. */
+    static pascals: Unit<NumberType, dimension.Pressure> = kilograms
+      .per(meters)
+      .per(seconds.squared())
+      .withSymbol('Pa');
+  }
+
+  return WithValueType;
+}
+
+export const {pascals} = withValueType(NativeArithmetic);

--- a/src/radioactive/decay/index.ts
+++ b/src/radioactive/decay/index.ts
@@ -3,9 +3,12 @@ import {Quantity, Unit} from '../../unit';
 import {seconds} from '../../time';
 
 /** A quantity of radioactivity. */
-export type Radioactivity = Quantity<dimension.Radioactivity>;
+export type Radioactivity<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Radioactivity
+>;
 
 /** The becquerel, symbol `Bq`, is the SI unit for radioactivity. */
-export const becquerels: Unit<dimension.Radioactivity> = seconds
+export const becquerels: Unit<number, dimension.Radioactivity> = seconds
   .reciprocal()
   .withSymbol('Bq');

--- a/src/radioactive/decay/index.ts
+++ b/src/radioactive/decay/index.ts
@@ -1,6 +1,7 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {seconds} from '../../time';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of radioactivity. */
 export type Radioactivity<NumberType = number> = Quantity<
@@ -8,7 +9,19 @@ export type Radioactivity<NumberType = number> = Quantity<
   dimension.Radioactivity
 >;
 
-/** The becquerel, symbol `Bq`, is the SI unit for radioactivity. */
-export const becquerels: Unit<number, dimension.Radioactivity> = seconds
-  .reciprocal()
-  .withSymbol('Bq');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {seconds} = timeWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /** The becquerel, symbol `Bq`, is the SI unit for radioactivity. */
+    static becquerels: Unit<NumberType, dimension.Radioactivity> = seconds
+      .reciprocal()
+      .withSymbol('Bq');
+  }
+
+  return WithValueType;
+}
+
+export const {becquerels} = withValueType(NativeArithmetic);

--- a/src/radioactive/dose/index.ts
+++ b/src/radioactive/dose/index.ts
@@ -4,16 +4,16 @@ import {meters} from '../../length';
 import {seconds} from '../../time';
 
 /** A quantity of a radioactive dose. */
-export type Dose = Quantity<dimension.Dose>;
+export type Dose<NumberType = number> = Quantity<NumberType, dimension.Dose>;
 
 /** The gray, symbol `Gy`, is the SI unit for absorbed dose. */
-export const grays: Unit<dimension.Dose> = meters
+export const grays: Unit<number, dimension.Dose> = meters
   .squared()
   .per(seconds.squared())
   .withSymbol('Gy');
 
 /** The sievert, symbol `Sv`, is the SI unit for equivalent dose. */
-export const sieverts: Unit<dimension.Dose> = meters
+export const sieverts: Unit<number, dimension.Dose> = meters
   .squared()
   .per(seconds.squared())
   .withSymbol('Sv');

--- a/src/radioactive/dose/index.ts
+++ b/src/radioactive/dose/index.ts
@@ -1,19 +1,33 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../../arithmetic';
 import {Quantity, Unit} from '../../unit';
-import {meters} from '../../length';
-import {seconds} from '../../time';
+import {withValueType as lengthWithValueType} from '../../length';
+import {withValueType as timeWithValueType} from '../../time';
 
 /** A quantity of a radioactive dose. */
 export type Dose<NumberType = number> = Quantity<NumberType, dimension.Dose>;
 
-/** The gray, symbol `Gy`, is the SI unit for absorbed dose. */
-export const grays: Unit<number, dimension.Dose> = meters
-  .squared()
-  .per(seconds.squared())
-  .withSymbol('Gy');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters} = lengthWithValueType(arithmetic);
+  const {seconds} = timeWithValueType(arithmetic);
 
-/** The sievert, symbol `Sv`, is the SI unit for equivalent dose. */
-export const sieverts: Unit<number, dimension.Dose> = meters
-  .squared()
-  .per(seconds.squared())
-  .withSymbol('Sv');
+  class WithValueType {
+    private constructor() {}
+
+    /** The gray, symbol `Gy`, is the SI unit for absorbed dose. */
+    static grays: Unit<NumberType, dimension.Dose> = meters
+      .squared()
+      .per(seconds.squared())
+      .withSymbol('Gy');
+
+    /** The sievert, symbol `Sv`, is the SI unit for equivalent dose. */
+    static sieverts: Unit<NumberType, dimension.Dose> = meters
+      .squared()
+      .per(seconds.squared())
+      .withSymbol('Sv');
+  }
+
+  return WithValueType;
+}
+
+export const {grays, sieverts} = withValueType(NativeArithmetic);

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -1,7 +1,7 @@
 import * as dimension from '../dimension';
 import {Quantity, makeUnit} from '../unit';
 
-export type Scalar = Quantity<dimension.One>;
+export type Scalar<NumberType = number> = Quantity<NumberType, dimension.One>;
 export const scalar = makeUnit('', dimension.One);
 
 export const percent = scalar.times(1e-2).withSymbol('%');

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -1,9 +1,24 @@
 import * as dimension from '../dimension';
-import {Quantity, makeUnit} from '../unit';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Quantity, makeUnitFactory} from '../unit';
 
 export type Scalar<NumberType = number> = Quantity<NumberType, dimension.One>;
-export const scalar = makeUnit('', dimension.One);
 
-export const percent = scalar.times(1e-2).withSymbol('%');
-export const permille = scalar.times(1e-3).withSymbol('‰');
-export const permyriad = scalar.times(1e-4).withSymbol('‱');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    static scalar = makeUnit('', dimension.One);
+
+    static percent = WithValueType.scalar.times(1e-2).withSymbol('%');
+    static permille = WithValueType.scalar.times(1e-3).withSymbol('‰');
+    static permyriad = WithValueType.scalar.times(1e-4).withSymbol('‱');
+  }
+
+  return WithValueType;
+}
+
+export const {scalar, percent, permille, permyriad} =
+  withValueType(NativeArithmetic);

--- a/src/speed/index.ts
+++ b/src/speed/index.ts
@@ -1,28 +1,49 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {feet, kilometers, meters, miles, nauticalMiles} from '../length';
-import {hours, seconds} from '../time';
+import {withValueType as lengthWithValueType} from '../length';
+import {withValueType as timeWithValueType} from '../time';
 
 /** A quantity of length. */
 export type Speed<NumberType = number> = Quantity<NumberType, dimension.Speed>;
 
-/** The meter per second, symbol `m/s`, is the SI unit for speed. */
-export const metersPerSecond: Unit<number, dimension.Speed> = meters
-  .per(seconds)
-  .withSymbol('m/s');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters, kilometers, miles, nauticalMiles, feet} =
+    lengthWithValueType(arithmetic);
+  const {seconds, hours} = timeWithValueType(arithmetic);
 
-export const kilometersPerHour: Unit<number, dimension.Speed> = kilometers
-  .per(hours)
-  .withSymbol('km/h');
+  class WithValueType {
+    private constructor() {}
 
-export const milesPerHour: Unit<number, dimension.Speed> = miles
-  .per(hours)
-  .withSymbol('mph');
+    /** The meter per second, symbol `m/s`, is the SI unit for speed. */
+    static metersPerSecond: Unit<NumberType, dimension.Speed> = meters
+      .per(seconds)
+      .withSymbol('m/s');
 
-export const knots: Unit<number, dimension.Speed> = nauticalMiles
-  .per(hours)
-  .withSymbol('kn');
+    static kilometersPerHour: Unit<NumberType, dimension.Speed> = kilometers
+      .per(hours)
+      .withSymbol('km/h');
 
-export const feetPerSecond: Unit<number, dimension.Speed> = feet
-  .per(seconds)
-  .withSymbol('fps');
+    static milesPerHour: Unit<NumberType, dimension.Speed> = miles
+      .per(hours)
+      .withSymbol('mph');
+
+    static knots: Unit<NumberType, dimension.Speed> = nauticalMiles
+      .per(hours)
+      .withSymbol('kn');
+
+    static feetPerSecond: Unit<NumberType, dimension.Speed> = feet
+      .per(seconds)
+      .withSymbol('fps');
+  }
+
+  return WithValueType;
+}
+
+export const {
+  metersPerSecond,
+  kilometersPerHour,
+  milesPerHour,
+  knots,
+  feetPerSecond
+} = withValueType(NativeArithmetic);

--- a/src/speed/index.ts
+++ b/src/speed/index.ts
@@ -4,25 +4,25 @@ import {feet, kilometers, meters, miles, nauticalMiles} from '../length';
 import {hours, seconds} from '../time';
 
 /** A quantity of length. */
-export type Speed = Quantity<dimension.Speed>;
+export type Speed<NumberType = number> = Quantity<NumberType, dimension.Speed>;
 
 /** The meter per second, symbol `m/s`, is the SI unit for speed. */
-export const metersPerSecond: Unit<dimension.Speed> = meters
+export const metersPerSecond: Unit<number, dimension.Speed> = meters
   .per(seconds)
   .withSymbol('m/s');
 
-export const kilometersPerHour: Unit<dimension.Speed> = kilometers
+export const kilometersPerHour: Unit<number, dimension.Speed> = kilometers
   .per(hours)
   .withSymbol('km/h');
 
-export const milesPerHour: Unit<dimension.Speed> = miles
+export const milesPerHour: Unit<number, dimension.Speed> = miles
   .per(hours)
   .withSymbol('mph');
 
-export const knots: Unit<dimension.Speed> = nauticalMiles
+export const knots: Unit<number, dimension.Speed> = nauticalMiles
   .per(hours)
   .withSymbol('kn');
 
-export const feetPerSecond: Unit<dimension.Speed> = feet
+export const feetPerSecond: Unit<number, dimension.Speed> = feet
   .per(seconds)
   .withSymbol('fps');

--- a/src/temperature/index.ts
+++ b/src/temperature/index.ts
@@ -1,5 +1,6 @@
 import * as dimension from './dimension';
-import {Quantity, makeUnit} from '../unit';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Quantity, makeUnitFactory} from '../unit';
 
 /** A quantity of thermodynamic temperature. */
 export type Temperature<NumberType = number> = Quantity<
@@ -7,15 +8,29 @@ export type Temperature<NumberType = number> = Quantity<
   dimension.Temperature
 >;
 
-/**
- * The kelvin, symbol `K`, is the SI unit of thermodynamic temperature. All
- * other units in this module are defined as scaled values of the kelvin.
- */
-export const kelvin = makeUnit('K', dimension.Temperature);
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
 
-export const celsius = kelvin.withOffset(-273.15).withSymbol('ºC');
-export const fahrenheit = kelvin
-  .times(5 / 9)
-  .withOffset(-459.67)
-  .withSymbol('ºF');
-export const rankine = kelvin.times(1 / 1.8).withSymbol('ºR');
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The kelvin, symbol `K`, is the SI unit of thermodynamic temperature. All
+     * other units in this module are defined as scaled values of the kelvin.
+     */
+    static kelvin = makeUnit('K', dimension.Temperature);
+
+    static celsius = WithValueType.kelvin.withOffset(-273.15).withSymbol('ºC');
+    static fahrenheit = WithValueType.kelvin
+      .times(5)
+      .per(9)
+      .withOffset(-459.67)
+      .withSymbol('ºF');
+    static rankine = WithValueType.kelvin.per(1.8).withSymbol('ºR');
+  }
+
+  return WithValueType;
+}
+
+export const {kelvin, celsius, fahrenheit, rankine} =
+  withValueType(NativeArithmetic);

--- a/src/temperature/index.ts
+++ b/src/temperature/index.ts
@@ -2,7 +2,10 @@ import * as dimension from './dimension';
 import {Quantity, makeUnit} from '../unit';
 
 /** A quantity of thermodynamic temperature. */
-export type Temperature = Quantity<dimension.Temperature>;
+export type Temperature<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Temperature
+>;
 
 /**
  * The kelvin, symbol `K`, is the SI unit of thermodynamic temperature. All

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -1,25 +1,47 @@
 import * as dimension from './dimension';
-import {Quantity, SiPrefix, makeUnit} from '../unit';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
+import {Quantity, makeUnitFactory} from '../unit';
 
 /** A quantity of time. */
 export type Time<NumberType = number> = Quantity<NumberType, dimension.Time>;
 
-/**
- * The second, symbol `s`, is the SI base unit of time. All other units in
- * this module are defined as scaled values of the second.
- */
-export const seconds = makeUnit('s', dimension.Time);
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {makeUnit} = makeUnitFactory(arithmetic);
 
-export const [milliseconds, microseconds, nanoseconds] = (
-  ['m', 'μ', 'n'] as SiPrefix[]
-).map(x => seconds.withSiPrefix(x));
+  class WithValueType {
+    private constructor() {}
 
-export const [s, msec, usec] = [
+    /**
+     * The second, symbol `s`, is the SI base unit of time. All other units in
+     * this module are defined as scaled values of the second.
+     */
+    static seconds = makeUnit('s', dimension.Time);
+
+    static milliseconds = WithValueType.seconds.withSiPrefix('m');
+    static microseconds = WithValueType.seconds.withSiPrefix('μ');
+    static nanoseconds = WithValueType.seconds.withSiPrefix('n');
+
+    static s = WithValueType.seconds;
+    static msec = WithValueType.milliseconds;
+    static usec = WithValueType.microseconds;
+    static nsec = WithValueType.nanoseconds;
+
+    static minutes = WithValueType.seconds.times(60).withSymbol('m');
+    static hours = WithValueType.minutes.times(60).withSymbol('h');
+  }
+
+  return WithValueType;
+}
+
+export const {
   seconds,
   milliseconds,
   microseconds,
-  nanoseconds
-];
-
-export const minutes = seconds.times(60).withSymbol('m');
-export const hours = minutes.times(60).withSymbol('h');
+  nanoseconds,
+  s,
+  msec,
+  usec,
+  nsec,
+  minutes,
+  hours
+} = withValueType(NativeArithmetic);

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -2,7 +2,7 @@ import * as dimension from './dimension';
 import {Quantity, SiPrefix, makeUnit} from '../unit';
 
 /** A quantity of time. */
-export type Time = Quantity<dimension.Time>;
+export type Time<NumberType = number> = Quantity<NumberType, dimension.Time>;
 
 /**
  * The second, symbol `s`, is the SI base unit of time. All other units in

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -442,7 +442,6 @@ export const makeUnitFactory = <NumberType>(
   ): Unit<NumberType, D> {
     // Return a callable object that constructs a quantity of the given unit.
     // See class comment for more details.
-    // TODO: Check type of Amount
     function makeQuantity(amount: number): Quantity<NumberType, D> {
       return new QuantityImpl<D>(
         fromNative(amount),

--- a/src/volume/index.ts
+++ b/src/volume/index.ts
@@ -1,6 +1,7 @@
 import * as dimension from './dimension';
+import {Arithmetic, NativeArithmetic} from '../arithmetic';
 import {Quantity, Unit} from '../unit';
-import {meters} from '../length';
+import {withValueType as lengthWithValueType} from '../length';
 
 /** A quantity of volume. */
 export type Volume<NumberType = number> = Quantity<
@@ -8,10 +9,22 @@ export type Volume<NumberType = number> = Quantity<
   dimension.Volume
 >;
 
-/**
- * The cubic meter, symbol `m³`, is the SI unit of area. All other units in
- * this module are defined as scaled values of the cubic meter.
- */
-export const cubicMeters: Unit<number, dimension.Volume> = meters
-  .cubed()
-  .withSymbol('m³');
+export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
+  const {meters} = lengthWithValueType(arithmetic);
+
+  class WithValueType {
+    private constructor() {}
+
+    /**
+     * The cubic meter, symbol `m³`, is the SI unit of area. All other units in
+     * this module are defined as scaled values of the cubic meter.
+     */
+    static cubicMeters: Unit<NumberType, dimension.Volume> = meters
+      .cubed()
+      .withSymbol('m³');
+  }
+
+  return WithValueType;
+}
+
+export const {cubicMeters} = withValueType(NativeArithmetic);

--- a/src/volume/index.ts
+++ b/src/volume/index.ts
@@ -3,12 +3,15 @@ import {Quantity, Unit} from '../unit';
 import {meters} from '../length';
 
 /** A quantity of volume. */
-export type Volume = Quantity<dimension.Volume>;
+export type Volume<NumberType = number> = Quantity<
+  NumberType,
+  dimension.Volume
+>;
 
 /**
  * The cubic meter, symbol `m³`, is the SI unit of area. All other units in
  * this module are defined as scaled values of the cubic meter.
  */
-export const cubicMeters: Unit<dimension.Volume> = meters
+export const cubicMeters: Unit<number, dimension.Volume> = meters
   .cubed()
   .withSymbol('m³');

--- a/test/angle_test.ts
+++ b/test/angle_test.ts
@@ -102,8 +102,8 @@ describe('angle', () => {
 
 // TODO(bunge): Move this to a Chai method instead.
 function expectCloseTo<D extends Dimensions>(
-  actual: Quantity<D>,
-  expected: Quantity<D>
+  actual: Quantity<number, D>,
+  expected: Quantity<number, D>
 ) {
   return expect(
     actual.isCloseTo(expected, 0.0001),

--- a/test/time_test.ts
+++ b/test/time_test.ts
@@ -6,7 +6,9 @@ describe('time smoke tests', () => {
     {a: nanoseconds(1234), b: usec(1.234)},
     {a: usec(1234), b: msec(1.234)},
     {a: msec(1234), b: s(1.234)},
+    // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
     {a: s(1234), b: minutes(20.566666666666667)},
+    // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
     {a: minutes(1234), b: hours(20.566666666666667)}
   ];
 

--- a/test/unit_test.ts
+++ b/test/unit_test.ts
@@ -50,6 +50,27 @@ export const StringArithmetic: Arithmetic<string> = {
   },
   compare: function (left: string, right: string): number {
     return Number(left) - Number(right);
+  },
+  sin: function (value: string): string {
+    return Math.sin(Number(value)).toString();
+  },
+  cos: function (value: string): string {
+    return Math.cos(Number(value)).toString();
+  },
+  tan: function (value: string): string {
+    return Math.tan(Number(value)).toString();
+  },
+  asin: function (value: string): string {
+    return Math.asin(Number(value)).toString();
+  },
+  acos: function (value: string): string {
+    return Math.acos(Number(value)).toString();
+  },
+  atan: function (value: string): string {
+    return Math.atan(Number(value)).toString();
+  },
+  atan2: function (left: string, right: string): string {
+    return Math.atan2(Number(left), Number(right)).toString();
   }
 };
 

--- a/test/unit_test.ts
+++ b/test/unit_test.ts
@@ -50,27 +50,6 @@ export const StringArithmetic: Arithmetic<string> = {
   },
   compare: function (left: string, right: string): number {
     return Number(left) - Number(right);
-  },
-  sin: function (value: string): string {
-    return Math.sin(Number(value)).toString();
-  },
-  cos: function (value: string): string {
-    return Math.cos(Number(value)).toString();
-  },
-  tan: function (value: string): string {
-    return Math.tan(Number(value)).toString();
-  },
-  asin: function (value: string): string {
-    return Math.asin(Number(value)).toString();
-  },
-  acos: function (value: string): string {
-    return Math.acos(Number(value)).toString();
-  },
-  atan: function (value: string): string {
-    return Math.atan(Number(value)).toString();
-  },
-  atan2: function (left: string, right: string): string {
-    return Math.atan2(Number(left), Number(right)).toString();
   }
 };
 


### PR DESCRIPTION
The implementation is based on the discussion we had on #5, and hopefully it should close it too.
And the pull request is totally retrocompatible.

So I had to wrap `makeUnit` into a function `makeUnitFactory` which has the arithmetic parameter.
All the calculations are done using this arithmetic.

Then each unit exposes a function `withValueType` of the following form:
```ts
export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
  const {makeUnit} = makeUnitFactory(arithmetic);
  const {meters} = lengthWithValueType(arithmetic);

  class WithValueType {
    private constructor() {}

    static unit1 = makeUnit('A', dimension.Current);
    static unit2 = WithValueType.unit1.cubed()
    static unit3 = meters.cubed()
  }

  return WithValueType;
}

export const {unit1, unit2, unit3} = withValueType(NativeArithmetic);
```

The reason I decided to use a class with static function is to reduce duplications.
I did not like to have units written uselessly 3 times:
```ts
export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
  const {makeUnit} = makeUnitFactory(arithmetic);
  const {meters} = lengthWithValueType(arithmetic);

  const unit1 = makeUnit('A', dimension.Current);
  const unit2 = unit1.cubed()
  const unit3 = meters.cubed()

  return {
     unit1,
     unit2,
     unit3,
  };
}

export const {unit1, unit2, unit3} = withValueType(NativeArithmetic);
```

Something that could be improved in the future if needed is the ability to set as input for the different function "number | NumberType" instead of just "number".

I also update the dependencies as it was straight forward.

Let me know if you have any questions.