### PR TITLE
Add support of NumberType and string as input for unit and quantity functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ import {withValueType as temperatureWithValueType} from '@buge/ts-units/temperat
 import {withValueType as angleWithValueType} from '@buge/ts-units/angle';
 
 const DecimalArithmetic: Arithmetic<Decimal> = {
-  fromNative(value: number): Decimal {
+  from(value: number | string | Decimal): Decimal {
     return new Decimal(value);
   },
   toNative(value: Decimal): number {
@@ -668,24 +668,3 @@ respectively, we model these as:
 type Angle = {angle: 1};
 type SolidAngle = {angle: 2};
 ```
-
-### Lack of input flexibility
-
-Currently when declaring quantities you can only use native number as input.
-
-```ts
-import {meters} from '@buge/ts-units/length';
-// It won't work
-const length = meters('5');
-```
-
-```ts
-import {withValueType} from '@buge/ts-units/length';
-const { meters } = withValueType(DecimalArithmetic);
-// It won't work
-const length = meters(new Decimal(5));
-```
-
-Moreover, the arithmetic function of `Unit` and `Quantity` also support only native number.
-
-It could be improve in future

--- a/src/angle/index.ts
+++ b/src/angle/index.ts
@@ -10,7 +10,6 @@ export function withValueType<NumberType>(
   geometric: Geometric<NumberType>
 ) {
   const {makeUnit} = makeUnitFactory(arithmetic);
-  const {toNative} = arithmetic;
   const {sin, cos, tan, asin, acos, atan, atan2} = geometric;
 
   class WithValueType {
@@ -70,14 +69,14 @@ export function withValueType<NumberType>(
      * @param y A numeric expression representing the cartesian y-coordinate.
      */
     static atan2(x: NumberType, y: NumberType): Angle<NumberType> {
-      return WithValueType.radians(toNative(atan2(x, y)));
+      return WithValueType.radians(atan2(x, y));
     }
   }
 
   function liftRet(
     f: (x: NumberType) => NumberType
   ): (x: NumberType) => Angle<NumberType> {
-    return x => WithValueType.radians(toNative(f(x)));
+    return x => WithValueType.radians(f(x));
   }
 
   function liftUnary(

--- a/src/angle/solid/index.ts
+++ b/src/angle/solid/index.ts
@@ -17,7 +17,7 @@ export function withValueType<NumberType>(arithmetic: Arithmetic<NumberType>) {
 
     static steradians = makeUnit('sr', dimension.SolidAngle);
     static squareDegrees = WithValueType.steradians
-      .times(scalar(Math.PI).per(180).cubed().valueOf())
+      .times(scalar(Math.PI).per(180).cubed().value())
       .withSymbol('deg²');
   };
 }

--- a/src/arithmetic.ts
+++ b/src/arithmetic.ts
@@ -1,3 +1,5 @@
+import {assert} from './utils';
+
 /**
  * An arithmetic representation of a particular number type.
  *
@@ -11,7 +13,13 @@
  * For instance, you could implement it using [decimal.js]{@link https://github.com/MikeMcl/decimal.js}.
  */
 export interface Arithmetic<NumberType> {
-  fromNative(value: number): NumberType;
+  /**
+   * Return a NumberType of the input.
+   * If it is not possible, it should throw an error.
+   *
+   * @param value The value to convert to NumberType
+   */
+  from(value: number | string | NumberType): NumberType;
   toNative(value: NumberType): number;
   add(left: NumberType, right: NumberType): NumberType;
   sub(left: NumberType, right: NumberType): NumberType;
@@ -30,8 +38,13 @@ export interface Arithmetic<NumberType> {
  * based on the native number of JavaScript.
  */
 export const NativeArithmetic: Arithmetic<number> = {
-  fromNative: function (value: number): number {
-    return value;
+  from: function (value: number | string): number {
+    const convertedValue = Number(value);
+    assert(
+      !isNaN(convertedValue),
+      `Input '${value}' cannot be converted to a number`
+    );
+    return convertedValue;
   },
   toNative: function (value: number): number {
     return value;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg);
+  }
+}

--- a/test/unit-factory_test.ts
+++ b/test/unit-factory_test.ts
@@ -1,0 +1,143 @@
+import {Arithmetic, NativeArithmetic} from '../src/arithmetic';
+import {expect} from 'chai';
+import {makeUnitFactory} from '../src/unit';
+
+class CustomNumber {
+  value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+}
+
+export const CustomArithmetic: Arithmetic<CustomNumber> = {
+  from: function (value): CustomNumber {
+    if (value instanceof CustomNumber) {
+      return value;
+    }
+    return new CustomNumber(NativeArithmetic.from(value));
+  },
+  toNative: function (value: CustomNumber): number {
+    return value.value;
+  },
+  add: function (left: CustomNumber, right: CustomNumber): CustomNumber {
+    return new CustomNumber(NativeArithmetic.add(left.value, right.value));
+  },
+  sub: function (left: CustomNumber, right: CustomNumber): CustomNumber {
+    return new CustomNumber(NativeArithmetic.sub(left.value, right.value));
+  },
+  mul: function (left: CustomNumber, right: CustomNumber): CustomNumber {
+    return new CustomNumber(NativeArithmetic.mul(left.value, right.value));
+  },
+  div: function (left: CustomNumber, right: CustomNumber): CustomNumber {
+    return new CustomNumber(NativeArithmetic.div(left.value, right.value));
+  },
+  pow: function (base: CustomNumber, exponent: CustomNumber): CustomNumber {
+    return new CustomNumber(NativeArithmetic.pow(base.value, exponent.value));
+  },
+  abs: function (value: CustomNumber): CustomNumber {
+    return new CustomNumber(NativeArithmetic.abs(value.value));
+  },
+  compare: function (left: CustomNumber, right: CustomNumber): number {
+    return NativeArithmetic.compare(left.value, right.value);
+  }
+};
+
+type Length = {length: 1};
+const Length: Length = {length: 1};
+
+describe('unitFactory', () => {
+  const meters = makeUnitFactory(CustomArithmetic).makeUnit('m', Length);
+
+  it('generates a unit', () => {
+    expect(meters.arithmetic).to.equal(CustomArithmetic);
+    expect(meters.symbol).to.equal('m');
+    expect(meters.dimension).to.equal(Length);
+    expect(meters.scale.value).to.equal(1);
+    expect(meters.offset.value).to.equal(0);
+  });
+
+  describe('Unit', () => {
+    it('generates a quantity with amount of different input types', () => {
+      const lengthNative = meters(5);
+      const lengthString = meters('5');
+      const lengthCustom = meters(new CustomNumber(5));
+
+      expect(lengthNative.unit).to.equal(meters);
+      expect(lengthString.unit).to.equal(meters);
+      expect(lengthCustom.unit).to.equal(meters);
+
+      expect(lengthNative.dimension).to.deep.equal(Length);
+      expect(lengthString.dimension).to.deep.equal(Length);
+      expect(lengthCustom.dimension).to.deep.equal(Length);
+
+      expect(lengthNative.amount.value).to.equal(5);
+      expect(lengthString.amount.value).to.equal(5);
+      expect(lengthCustom.amount.value).to.equal(5);
+    });
+
+    it('is multiply by various input type', () => {
+      const kilometersNative = meters.times(1000);
+      const kilometersString = meters.times('1000');
+      const kilometersCustom = meters.times(new CustomNumber(1000));
+
+      expect(kilometersNative.scale.value).to.equal(1000);
+      expect(kilometersString.scale.value).to.equal(1000);
+      expect(kilometersCustom.scale.value).to.equal(1000);
+    });
+
+    it('is divided by various input type', () => {
+      const kilometersNative = meters.per(0.001);
+      const kilometersString = meters.per('0.001');
+      const kilometersCustom = meters.per(new CustomNumber(0.001));
+
+      expect(kilometersNative.scale.value).to.equal(1000);
+      expect(kilometersString.scale.value).to.equal(1000);
+      expect(kilometersCustom.scale.value).to.equal(1000);
+    });
+  });
+
+  describe('Quantity', () => {
+    const length = meters(6);
+
+    it('add quantity of different input types', () => {
+      const lengthNative = length.plus(2);
+      const lengthString = length.plus('2');
+      const lengthCustom = length.plus(new CustomNumber(2));
+
+      expect(lengthNative.amount.value).to.equal(8);
+      expect(lengthString.amount.value).to.equal(8);
+      expect(lengthCustom.amount.value).to.equal(8);
+    });
+
+    it('remove quantity of different input type', () => {
+      const lengthNative = length.minus(2);
+      const lengthString = length.minus('2');
+      const lengthCustom = length.minus(new CustomNumber(2));
+
+      expect(lengthNative.amount.value).to.equal(4);
+      expect(lengthString.amount.value).to.equal(4);
+      expect(lengthCustom.amount.value).to.equal(4);
+    });
+
+    it('multiply quantity by different input type', () => {
+      const lengthNative = length.times(2);
+      const lengthString = length.times('2');
+      const lengthCustom = length.times(new CustomNumber(2));
+
+      expect(lengthNative.amount.value).to.equal(12);
+      expect(lengthString.amount.value).to.equal(12);
+      expect(lengthCustom.amount.value).to.equal(12);
+    });
+
+    it('divide quantity by different input type', () => {
+      const lengthNative = length.per(2);
+      const lengthString = length.per('2');
+      const lengthCustom = length.per(new CustomNumber(2));
+
+      expect(lengthNative.amount.value).to.equal(3);
+      expect(lengthString.amount.value).to.equal(3);
+      expect(lengthCustom.amount.value).to.equal(3);
+    });
+  });
+});

--- a/test/unit_test.ts
+++ b/test/unit_test.ts
@@ -1,5 +1,4 @@
-import {Quantity, Unit, makeUnit, makeUnitFactory} from '../src/unit';
-import {Arithmetic} from '../src/arithmetic';
+import {Quantity, Unit, makeUnit} from '../src/unit';
 import {expect} from 'chai';
 
 type Temperature = {temperature: 1};
@@ -22,36 +21,6 @@ const Frequency: Frequency = {time: -1};
 
 type Speed = {length: 1; time: -1};
 const Speed: Speed = {length: 1, time: -1};
-
-export const StringArithmetic: Arithmetic<string> = {
-  fromNative: function (value: number): string {
-    return value.toString();
-  },
-  toNative: function (value: string): number {
-    return Number(value);
-  },
-  add: function (left: string, right: string): string {
-    return (Number(left) + Number(right)).toString();
-  },
-  sub: function (left: string, right: string): string {
-    return (Number(left) - Number(right)).toString();
-  },
-  mul: function (left: string, right: string): string {
-    return (Number(left) * Number(right)).toString();
-  },
-  div: function (left: string, right: string): string {
-    return (Number(left) / Number(right)).toString();
-  },
-  pow: function (base: string, exponent: string): string {
-    return (Number(base) ** Number(exponent)).toString();
-  },
-  abs: function (value: string): string {
-    return Math.abs(Number(value)).toString();
-  },
-  compare: function (left: string, right: string): number {
-    return Number(left) - Number(right);
-  }
-};
 
 describe('unit', () => {
   describe('Unit', () => {
@@ -583,30 +552,6 @@ describe('unit', () => {
 
         const temperature = fahrenheit(305.15);
         expect(temperature.valueOf()).to.be.closeTo(424.9, 0.0000001);
-      });
-    });
-  });
-
-  describe('Factory', () => {
-    describe('given custom arithmetic', () => {
-      it('generates a quantity with the given amount', () => {
-        const {makeUnit} = makeUnitFactory(StringArithmetic);
-        const meters = makeUnit('m', Length);
-        const length = meters(3.8);
-
-        expect(length.amount).to.equal('3.8');
-        expect(length.unit).to.equal(meters);
-        expect(length.dimension).to.deep.equal(Length);
-      });
-
-      it('generates a quantity with the given amount for scaled units', () => {
-        const {makeUnit} = makeUnitFactory(StringArithmetic);
-        const feet = makeUnit('m', Length).times(0.3048);
-        const length = feet(3.8);
-
-        expect(length.amount).to.equal('3.8');
-        expect(length.unit).to.equal(feet);
-        expect(length.dimension).to.deep.equal(Length);
       });
     });
   });


### PR DESCRIPTION
Now we can do meters('5') or meters(5) or meters(new Decimal(5)) if DecimalArithmetic was implemented.

Concerning the function isUnit and isQuantity:
As we are doing composition using ``withValueType` for some units, we cannot do "instanceof UnitImpl" or "instanceof QuantityImpl". Because, they will not have the same reference.

As a workaround, I decided to use Arithmetic object. I am not sure it is the best solution, but it is working.

Another idea would be to create a random class G outside of makeUnitFactory, and then make UnitImpl extends it.
I didn't dig to much in that solution.

Another idea would be to instead check for "isUnit" or "isQuantity" instead verify if the input is "number | string | NumberType".
We would need to add a new function to the arithmetic "isNumber(string | number | NumberType): boolean".
It should be doable, but the "isNumber" function and "from" function would be a bit trickier to write I think.

Let me know about your opinion.
